### PR TITLE
[DM-21880] Have the query monkey work around auth

### DIFF
--- a/kube/stable/querymonkey-deployment.yaml
+++ b/kube/stable/querymonkey-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         image: lsstdax/querymonkey:latest
         env:
         - name: TAP_URL
-          value: "https://lsst-lsp-stable.ncsa.illinois.edu/api/tap"
+          value: "http://tap-service/tap"
         - name: SLACK_WEBHOOK
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Such a smart monkey.  Let's use the internal service
IP to connect.  While I'm a bit worried that this won't test
out the ingress parts, honestly that has to be part of it,
since there's no automated way to get a token for a service.