### PR TITLE
[DM-22959] Allow configuration of who can fiddle log setting

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - tap-network
     environment:
-      CATALINA_OPTS: "-Dqservuser.jdbc.username=qsmaster -Dqservuser.jdbc.password= -Dqservuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dqservuser.jdbc.url=jdbc:mysql://mock-qserv:3306/ -Dtapuser.jdbc.username=TAP_SCHEMA -Dtapuser.jdbc.password=TAP_SCHEMA -Dtapuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dtapuser.jdbc.url=jdbc:mysql://tap-schema-db:3306/ -Dca.nrc.cadc.reg.client.RegistryClient.local=true -Duws.jdbc.username=postgres -Duws.jdbc.driverClassName=org.postgresql.Driver -Duws.jdbc.url=jdbc:postgresql://uws-db/ -Dca.nrc.cadc.auth.Authenticator=org.opencadc.tap.impl.AuthenticatorImpl"
+      CATALINA_OPTS: "-Dqservuser.jdbc.username=qsmaster -Dqservuser.jdbc.password= -Dqservuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dqservuser.jdbc.url=jdbc:mysql://mock-qserv:3306/ -Dtapuser.jdbc.username=TAP_SCHEMA -Dtapuser.jdbc.password=TAP_SCHEMA -Dtapuser.jdbc.driverClassName=com.mysql.cj.jdbc.Driver -Dtapuser.jdbc.url=jdbc:mysql://tap-schema-db:3306/ -Dca.nrc.cadc.reg.client.RegistryClient.local=true -Duws.jdbc.username=postgres -Duws.jdbc.driverClassName=org.postgresql.Driver -Duws.jdbc.url=jdbc:postgresql://uws-db/ -Dca.nrc.cadc.auth.Authenticator=org.opencadc.tap.impl.AuthenticatorImpl -Dca.nrc.cadc.util.PropertiesReader.dir=/etc/creds/"
       GOOGLE_APPLICATION_CREDENTIALS: "/etc/google_creds.json"
     volumes:
       - './google_creds.json:/etc/google_creds.json'

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,10 @@
                 ca.nrc.cadc.uws
             </param-value>
         </init-param>
+        <init-param>
+            <param-name>logControlProperties</param-name>
+            <param-value>logcontrol.properties</param-value>
+        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,14 +24,6 @@
                 ca.nrc.cadc.uws
             </param-value>
         </init-param>
-        <init-param>
-            <param-name>logAccessGroup</param-name>
-            <param-value>CADC</param-value>
-        </init-param>
-        <!--<init-param>-->
-        <!--<param-name>groupAuthorizer</param-name>-->
-        <!--<param-value>ca.nrc.cadc.auth.CADCGroupAuthorizer</param-value>-->
-        <!--</init-param>-->
         <load-on-startup>1</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
First off, get rid of that group thing.  We don't have that group.

Then, set up the new PropertyReaders.dir to point to /etc/creds, where the secrets are placed.  If the file doesn't exist, that's fine.  Then point it at the file in the directory in web.xml (PropertyReader will look in the directory set in the system property).