### PR TITLE
Update querymonkey templates for datasets in small qserv instance

### DIFF
--- a/integration_test/querymonkey/test_queries/circle.sql
+++ b/integration_test/querymonkey/test_queries/circle.sql
@@ -1,1 +1,1 @@
-SELECT 'monkey', ra, decl FROM wise_00.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, decl), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1
+SELECT 'monkey', ra, dec FROM wise_01.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1

--- a/integration_test/querymonkey/test_queries/count.sql
+++ b/integration_test/querymonkey/test_queries/count.sql
@@ -1,1 +1,1 @@
-SELECT 'monkey', COUNT(*) FROM sdss_stripe82_01.RunDeepSource
+SELECT 'monkey', COUNT(*) FROM wise_01.allwise_p3as_mep

--- a/integration_test/querymonkey/test_queries/neighbor_count.sql
+++ b/integration_test/querymonkey/test_queries/neighbor_count.sql
@@ -1,5 +1,5 @@
-SELECT 'monkey', count(o1.id)
-FROM sdss_stripe82_01.RunDeepSource o1, sdss_stripe82_01.RunDeepSource o2
-WHERE CONTAINS(POINT('ICRS', o1.coord_ra, o1.coord_decl), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1
-  AND DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) < 0.016
-  AND o1.id <> o2.id
+SELECT 'monkey', count(o1.cntr)
+FROM wise_01.allwise_p3as_psd o1, wise_01.allwise_p3as_psd o2
+WHERE CONTAINS(POINT('ICRS', o1.ra, o1.dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1
+  AND DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) < 0.016
+  AND o1.cntr <> o2.cntr

--- a/integration_test/querymonkey/test_queries/neighbor_far.sql
+++ b/integration_test/querymonkey/test_queries/neighbor_far.sql
@@ -1,6 +1,6 @@
-SELECT 'monkey', o1.id AS id1, o2.id AS id2,
-  DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) AS d
-FROM sdss_stripe82_01.RunDeepSource o1, sdss_stripe82_01.RunDeepSource o2
-WHERE CONTAINS(POINT('ICRS', o1.coord_ra, o1.coord_decl), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ rsmall }})) = 1
-  AND DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) < 0.016
-  AND o1.id <> o2.id
+SELECT 'monkey', o1.cntr AS id1, o2.cntr AS id2,
+  DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) AS d
+FROM wise_01.allwise_p3as_psd o1, wise_01.allwise_p3as_psd o2
+WHERE CONTAINS(POINT('ICRS', o1.ra, o1.dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ rsmall }})) = 1
+  AND DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) < 0.016
+  AND o1.cntr <> o2.cntr

--- a/integration_test/querymonkey/test_queries/neighbor_near.sql
+++ b/integration_test/querymonkey/test_queries/neighbor_near.sql
@@ -1,6 +1,6 @@
-SELECT 'monkey', o1.id AS id1, o2.id AS id2,
-  DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) AS d
-FROM sdss_stripe82_01.RunDeepSource o1, sdss_stripe82_01.RunDeepSource o2
-WHERE CONTAINS(POINT('ICRS', o1.coord_ra, o1.coord_decl), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1
-  AND DISTANCE(POINT('ICRS', o1.coord_ra, o1.coord_decl), POINT('ICRS', o2.coord_ra, o2.coord_decl)) < 0.000277778
-  AND o1.id <> o2.id
+SELECT 'monkey', o1.cntr AS id1, o2.cntr AS id2,
+  DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) AS d
+FROM wise_01.allwise_p3as_psd o1, wise_01.allwise_p3as_psd o2
+WHERE CONTAINS(POINT('ICRS', o1.ra, o1.dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ r1 }})) = 1
+  AND DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) < 0.000277778
+  AND o1.cntr <> o2.cntr

--- a/integration_test/querymonkey/test_queries/polygon.sql
+++ b/integration_test/querymonkey/test_queries/polygon.sql
@@ -1,1 +1,1 @@
-SELECT 'monkey', ra, decl FROM wise_00.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, decl), POLYGON('ICRS', {{ ra }}, {{ limit_dec(dec + r1) }}, {{ ra + r2 }}, {{ dec }}, {{ ra }}, {{ limit_dec(dec - r3) }}, {{ ra - r3 }}, {{ dec }})) = 1
+SELECT 'monkey', ra, dec FROM wise_01.allwise_p3as_mep WHERE CONTAINS(POINT('ICRS', ra, dec), POLYGON('ICRS', {{ ra }}, {{ limit_dec(dec + r1) }}, {{ ra + r2 }}, {{ dec }}, {{ ra }}, {{ limit_dec(dec - r3) }}, {{ ra - r3 }}, {{ dec }})) = 1


### PR DESCRIPTION
Minor updates:
* no SDSS data in small qserv; use wise_01 instead
* update ra/dec column names as appropriate
* update for new numeric Wise PKs
