### PR TITLE
[DM-30904] Use HTTP/1.1 for Gafaelfawr query

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/AuthenticatorImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/AuthenticatorImpl.java
@@ -42,7 +42,9 @@ public class AuthenticatorImpl implements Authenticator
 
     private static final String gafaelfawr_url = System.getProperty("gafaelfawr_url");
 
-    private static final HttpClient client = HttpClient.newHttpClient();
+    private static final HttpClient client = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .build();
 
     public AuthenticatorImpl()
     {


### PR DESCRIPTION
We're getting the following log messages periodically:

```
2021-06-25 17:53:27.068 TAP ObsCore [http-nio-8080-exec-4] WARN  AuthenticatorImpl  - IOException while getting info from Gafaelfawr
2021-06-25 17:53:27.068 TAP ObsCore [http-nio-8080-exec-4] WARN  AuthenticatorImpl  - java.io.IOException: /10.133.0.91:49064: GOAWAY received
```

which seems to point to missing support in the Java HTTP/2 client
library for closing connections and retrying requests.  Switch to
HTTP/1.1 since HTTP/2 isn't offering many advantages and seems to
be buggy.