### PR TITLE
Use Python 3.10 for async reaper

### DIFF
--- a/.github/workflows/reap.yaml
+++ b/.github/workflows/reap.yaml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
       - name: Install tools dependencies
         run: pip install -r tools/requirements.txt
 


### PR DESCRIPTION
The async reaper action is failing because it can't install the
dependencies of google-cloud-storage.  Assume that this is because
ubuntu:latest comes with too old of a version of Python and try
installing Python 3.10 first to see if that fixes the problem.