### PR TITLE
Added unzip installation to TAP Dockerfile

### DIFF
--- a/docker/Dockerfile.lsst-tap-service
+++ b/docker/Dockerfile.lsst-tap-service
@@ -1,5 +1,7 @@
 FROM tomcat:9.0
 
+RUN apt-get update
+RUN apt-get install unzip
 RUN rm -rf webapps/*
 
 ADD start.sh /usr/local/bin/


### PR DESCRIPTION
**Description:**
Include the installation of unzip in the TAP Dockerfile

**Issue:**
When attempting to run a recent build & deploy of the TAP service, the deployment failed with an error message 
> unzip: command not found
If the above description is correct, and judging from the symptoms, it seems that unzip is not installed by default in the tomcat:9:0 image. I have tried running a bare tomcat:9 docker run and can confirm that "unzip" is not available.

**Date when issue first spotted:**
2022/06/30

**Link to issue description:**
https://issuehint.com/issue/docker-library/tomcat/267

**Environment:**
Minikube version: v1.25.1

**Version tested:**
Latest (6c5cfae054b691214a0185fba4a8299c57dea33b)

**Fix:**
Include an apt-get install of unzip in the TAP Dockerfile