### PR TITLE
[DM-35704] Try to add unzip back

### DIFF
--- a/docker/Dockerfile.lsst-tap-service
+++ b/docker/Dockerfile.lsst-tap-service
@@ -2,6 +2,8 @@ FROM tomcat:9.0
 
 RUN rm -rf webapps/*
 
+RUN apt-get update && apt-get install -y zip
+
 ADD start.sh /usr/local/bin/
 ADD *.war webapps/
 


### PR DESCRIPTION
Apparently the new build of the same base container doesn't have
unzip by default.