### PR TITLE
[DM-35717] Increase from 6 to 24 threads

### DIFF
--- a/src/main/java/org/opencadc/tap/ws/QueryJobManager.java
+++ b/src/main/java/org/opencadc/tap/ws/QueryJobManager.java
@@ -26,7 +26,7 @@ public class QueryJobManager extends SimpleJobManager {
 
         // max threads: 6 == number of simultaneously running async queries (per
         // web server), plus sync queries, plus VOSI-tables queries
-        final JobExecutor jobExec = new ThreadPoolExecutor(jobPersist, QServQueryRunner.class, 6);
+        final JobExecutor jobExec = new ThreadPoolExecutor(jobPersist, QServQueryRunner.class, 24);
 
         super.setJobPersistence(jobPersist);
         super.setJobExecutor(jobExec);


### PR DESCRIPTION
I'm a bit confused why this is here, but it seems fine.  We normally
seem to get 12 threads of throughput, so I'm a bit confused to find it
to be 6.  Let's turn it to 24 and see what it ends up as - 24 or 48?