### PR TITLE
[DM-37254] Emit exception message as warning

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
+++ b/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
@@ -496,8 +496,8 @@ public class QServQueryRunner implements JobRunner
                 diagnostics.add(new Result("diag", URI.create("fail:"+dt)));
 
                 errorMessage = t.getClass().getSimpleName() + ":" + t.getMessage();
-                log.debug("BADNESS", t);
-                log.debug("Error message: " + errorMessage);
+                log.warn("BADNESS", t);
+                log.warn("Error message: " + errorMessage);
                 
                 log.debug("creating TableWriter for error...");
                 TableWriter ewriter = pfac.getErrorWriter();


### PR DESCRIPTION
Right now this is printed out at the debug level, but it will be a lot easier to find and get a hold of if we make it a warning.  Since this is an exception path, this shouldn't really add too much log spam, considering the rethrown messages are emitted after, but we seem to lose the first one which is the most important.