### PR TITLE
DM-38493: Make S3 bucket paths absolute.

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
@@ -170,7 +170,7 @@ public class ResultStoreImpl implements ResultStore {
 
     private URL getURL() throws MalformedURLException {
         if (bucketType.equals(new String("S3"))) {
-            return new URL(new URL(bucketURL), bucket+"/"+filename);
+            return new URL(new URL(bucketURL), "/"+bucket+"/"+filename);
         } else {
             return new URL(new URL(bucketURL), filename);
         }


### PR DESCRIPTION
This resolves a problem with bucket names containing ":" that can otherwise be interpreted as a URL scheme instead of a path component.

Note that this prevents the `bucketURL` endpoint from having a path component, but this is not a problem for any known S3 service.