### PR TITLE
DM-37934: Remove advertisements for ADQL geometry entities not supported by Qserv

### DIFF
--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -114,26 +114,9 @@
                 <form>POLYGON</form>
             </feature>
             <feature>
-                <form>REGION</form>
-            </feature>
-            <feature>
                 <form>CONTAINS</form>
             </feature>
-            <feature>
-                <form>INTERSECTS</form>
-            </feature>
-            <feature>
-                <form>AREA</form>
-            </feature>
-            <feature>
-                <form>CENTROID</form>
-            </feature>
-            <feature>
-                <form>COORD1</form>
-            </feature>
-            <feature>
-                <form>COORD2</form>
-            </feature>
+            <!-- REGION, INTERSECTS, AREA, CENTROID, COORD1, and COORD2 not supported by Qserv -->
         </languageFeatures>
     </language>
 
@@ -155,6 +138,8 @@
         <mime>text/tab-separated-values</mime>
         <alias>tsv</alias>
     </outputFormat>
+
+    <!-- uploadMethods are not yet supported by Qserv -->
 
     <retentionPeriod>
         <default>604800</default>


### PR DESCRIPTION
Following consultation with @ktlim and @iagaponenko (who might not be able to see this repo?) I'm removing statements from the Qserv-based TAP service's `/capabilities` response for ADQL constructs that are not currently supported in Qserv: `REGION`, `INTERSECTS`, `AREA`, `CENTROID`, `COORD1`, and `COORD2`.

Compared to the recent fix re: `UPLOAD`, this is less urgent, because Firefly does not (yet) condition its behavior on these features.