### PR TITLE
[DM-41951] setAutoCommit to false

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
+++ b/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
@@ -371,6 +371,7 @@ public class QServQueryRunner implements JobRunner
                     // and restrict to forward only so that client memory usage is minimal since
                     // we are only interested in reading the ResultSet once
 
+		    connection.setAutoCommit(false);
                     pstmt = connection.prepareStatement(sql);
                     pstmt.setFetchSize(1000);
                     pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);

--- a/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
@@ -103,8 +103,7 @@ public class ResultStoreImpl implements ResultStore {
     public URL put(final ResultSet resultSet,
                    final TableWriter<ResultSet> resultSetTableWriter)
         throws IOException {
-        OutputStream os;
-        os = getOutputStream();
+        OutputStream os = getOutputStream();
         resultSetTableWriter.write(resultSet, os);
         os.close();
         return getURL();
@@ -113,8 +112,7 @@ public class ResultStoreImpl implements ResultStore {
     @Override
     public URL put(Throwable throwable, TableWriter tableWriter)
         throws IOException {
-        OutputStream os;
-        os = getOutputStream();
+        OutputStream os = getOutputStream();
         tableWriter.write(throwable, os);
         os.close();
         return getURL();
@@ -124,8 +122,7 @@ public class ResultStoreImpl implements ResultStore {
     public URL put(final ResultSet resultSet,
                    final TableWriter<ResultSet> resultSetTableWriter,
                    final Integer integer) throws IOException {
-        OutputStream os;
-        os = getOutputStream();
+        OutputStream os = getOutputStream();
 
         if (integer == null) {
             resultSetTableWriter.write(resultSet, os);


### PR DESCRIPTION
By setting auto commit to false, it should reduce the memory usage and seems to be one of the parts of making sure we use a cursor for the select statements.  If we don't use a cursor then the jdbc driver reads everything into memory before returning it.