### PR TITLE
Changed target version for vosi, fixes issue with build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'org.opencadc:cadc-uws:[1.0,)'
     implementation 'org.opencadc:cadc-uws-server:[1.2,)'
     implementation 'org.opencadc:cadc-tap-server:[1.1.5,)'
-    implementation 'org.opencadc:cadc-vosi:[1.0,1.4)'
+    implementation 'org.opencadc:cadc-vosi:[1.4.1,)'
     implementation 'org.opencadc:cadc-adql:[1.1.13,)'
     implementation 'org.opencadc:cadc-tap-server-oracle:[1.0.0,)'
 


### PR DESCRIPTION
**Description:**
PR addresses issue where most recent version on main fails to build.
Build run locally using Gradle version 7.6 produces compilation errors:

```
/app/src/main/java/org/opencadc/tap/ws/TAPWebService.java:85: error: TAPWebService is not abstract and does not override abstract method getStatus() in AvailabilityPlugin
public class TAPWebService implements AvailabilityPlugin {
       ^
/app/src/main/java/org/opencadc/tap/ws/TAPWebService.java:119: error: getStatus() in TAPWebService cannot implement getStatus() in AvailabilityPlugin
    public Availability getStatus() {
                        ^
  return type Availability is not compatible with AvailabilityStatus
/app/src/main/java/org/opencadc/tap/ws/TAPWebService.java:118: error: method does not override or implement a method from a supertype
    @Override
```

**Likely Cause:**
Cause seemed to the version of cadc-vosi library that gets imported is in the range of 1.0 - 1.4, though the change to use Availability in the AvailabilityPlugin interface was introduced in a version 1.4.

**Relevant PR:**
https://rubinobs.atlassian.net/browse/DM-44561

**Fix:**
Set the target version to >= 1.4.1

