### PR TITLE
Upgrade mysql connector to 8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+# 2024-06-18
+
+## Other Changes
+
+- Upgrade mysql-connector to 8.4.0
+
 # 2024-06-11
 
 ## New features

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ dependencies {
 
     // Switch out this to use any supported database instead of PostgreSQL.
     // ## START CUSTOM DATABASE ##
-    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.13'
+
+    implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.4.0'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
     // ## END CUSTOM DATABASE ##
 


### PR DESCRIPTION
**Jira issue description:**

> 
> The mysql-connector-java version in the lsst-tap-service appears to be 8.0.13, which dates from 2018 (and is listed as having three direct vulnerabilities, but which are not that severe: [CVE-2022-21363](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21363), [CVE-2021-2471](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-2471), [CVE-2019-2692](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-2692)).
> 
> We should try updating to at least 8.0.33 or possibly [mysql-connector-j](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j) 8.4.0, which appears to be the most recent available.
> 
> Among other things, this should enable us to use TLS 1.3, which is a recommended mitigation for having Qserv exposed to the Internet.
> 

Jira issue: https://rubinobs.atlassian.net/browse/DM-44885
