### PR TITLE
Enable results redirect servlet for async TAP queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ lsst-tap-service is versioned with [semver](https://semver.org/). Dependencies a
 Find changes for the upcoming release in the project's [changelog.d](https://github.com/lsst-sqre/lsst-tap-service/tree/main/changelog.d/).
 
 <!-- scriv-insert-here -->
+# 2024-06-28
+
+## Other Changes
+
+- Change result handling, to use a redirect servlet. Addresses issue with async failing due to auth header propagation with clients like pyvo, topcat
 
 # 2024-06-18
 

--- a/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultStoreImpl.java
@@ -97,7 +97,8 @@ public class ResultStoreImpl implements ResultStore {
     private static final String bucket = System.getProperty("gcs_bucket");
     private static final String bucketURL = System.getProperty("gcs_bucket_url");
     private static final String bucketType = System.getProperty("gcs_bucket_type");
-
+    private static final String baseURL = System.getProperty("base_url");
+    private static final String pathPrefix = System.getProperty("path_prefix");
 
     @Override
     public URL put(final ResultSet resultSet,
@@ -166,11 +167,13 @@ public class ResultStoreImpl implements ResultStore {
     }
 
     private URL getURL() throws MalformedURLException {
+        String filepath = ""; 
         if (bucketType.equals(new String("S3"))) {
-            return new URL(new URL(bucketURL), "/"+bucket+"/"+filename);
+            filepath = "/" + bucket + "/" + filename;
         } else {
-            return new URL(new URL(bucketURL), filename);
+            filepath = filename;
         }
+        return new URL(baseURL + pathPrefix + "/results/" + filepath);
     }
 
     private URI getURI() {

--- a/src/main/java/org/opencadc/tap/impl/ResultsServlet.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultsServlet.java
@@ -1,0 +1,50 @@
+package org.opencadc.tap.impl;
+
+import org.apache.log4j.Logger;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * A servlet that handles redirecting to specific job results.
+ * This servlet extracts the VOTable file name from the request path and constructs a URL to redirect the client.
+ *
+ * @author stvoutsin
+ */
+public class ResultsServlet extends HttpServlet {
+    private static final Logger log = Logger.getLogger(ResultsServlet.class);
+    private static final String bucketURL = System.getProperty("gcs_bucket_url");
+
+    /**
+     * Processes GET requests by extracting the result filename from the request path and redirecting to the corresponding results URL.
+     * The filename is assumed to be the path info of the request URL, following the first '/' character.
+     *
+     * @param request  the HttpServletRequest object that contains the request
+     * @param response the HttpServletResponse object that contains the response
+     * @throws ServletException if an input or output error is detected when the servlet handles the GET request
+     * @throws IOException if the request for the GET could not be handled
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            String path = request.getPathInfo();
+            String redirectUrl = generateRedirectUrl(bucketURL, path);
+            response.sendRedirect(redirectUrl);
+        } catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "An error occurred while processing the request.");
+        }
+    }
+
+    /**
+     * Generates the redirect URL based on a path.
+     *
+     * @param path the request path
+     * @return the redirect URL constructed using the bucket URL and results file
+     */
+    private String generateRedirectUrl(String bucketUrlString, String path) {
+        String resultsFile  = path.substring(1);
+        return bucketUrlString + "/" + resultsFile;
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -106,6 +106,16 @@
         <load-on-startup>3</load-on-startup>
     </servlet>
 
+    <servlet>
+        <servlet-name>ResultsServlet</servlet-name>
+        <servlet-class>org.opencadc.tap.impl.ResultsServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>ResultsServlet</servlet-name>
+        <url-pattern>/results/*</url-pattern>
+    </servlet-mapping>
+
     <!-- the TAP Endpoints -->
     <servlet-mapping>
         <servlet-name>AsyncServlet</servlet-name>

--- a/src/test/java/org/opencadc/tap/impl/ResultsServletTest.java
+++ b/src/test/java/org/opencadc/tap/impl/ResultsServletTest.java
@@ -1,0 +1,66 @@
+package org.opencadc.tap.impl;
+
+import ca.nrc.cadc.tap.schema.ColumnDesc;
+import ca.nrc.cadc.tap.schema.SchemaDesc;
+import ca.nrc.cadc.tap.schema.TableDesc;
+import ca.nrc.cadc.tap.schema.TapDataType;
+import ca.nrc.cadc.tap.schema.TapSchema;
+import ca.nrc.cadc.util.Log4jInit;
+import ca.nrc.cadc.uws.Job;
+import ca.nrc.cadc.uws.Parameter;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import java.lang.reflect.Method;
+
+public class ResultsServletTest {
+
+    private static final Logger log = Logger.getLogger(ResultsServletTest.class);
+    
+    static
+    {
+        Log4jInit.setLevel("org.opencadc.tap.impl", Level.INFO);
+                
+    }
+    
+    Job job = new Job()
+    {
+        @Override
+        public String getID() { return "testJob"; }
+    };
+    
+    public ResultsServletTest() { }
+    
+    @Test
+    public void testGenerateRedirectUrl() throws Exception {
+        String bucketUrl = "https://tap-files.lsst.codes";
+        String expectedUrl = "https://tap-files.lsst.codes/result_qz4z5hf6qy5509p1.xml";
+        ResultsServlet resultsServlet = new ResultsServlet();
+        resultsServlet.init();
+        String path = "/result_qz4z5hf6qy5509p1.xml";
+        
+        Method method = ResultsServlet.class.getDeclaredMethod("generateRedirectUrl", String.class, String.class);
+        method.setAccessible(true);
+        String actualUrl = (String) method.invoke(resultsServlet, bucketUrl, path);
+        
+        assertEquals(expectedUrl, actualUrl);
+    }
+
+    @Test
+    public void testGenerateRedirectUrlWithBucket() throws Exception {
+        String bucketUrl = "https://tap-files.lsst.codes";
+        String expectedUrl = "https://tap-files.lsst.codes/bucket12345/result_qz4z5hf6qy5509p1.xml";
+        ResultsServlet resultsServlet = new ResultsServlet();
+        resultsServlet.init();
+        String path = "/bucket12345/result_qz4z5hf6qy5509p1.xml";
+        
+        Method method = ResultsServlet.class.getDeclaredMethod("generateRedirectUrl", String.class, String.class);
+        method.setAccessible(true);
+        String actualUrl = (String) method.invoke(resultsServlet, bucketUrl, path);
+        
+        assertEquals(expectedUrl, actualUrl);
+    }
+
+}


### PR DESCRIPTION
**Description**
PR modifies the Async results functionality, by adding a redirect servlet which serves under /results/*. TAP Async results (jobID/results/result) now link to this servlet (/results/resultID.xml) so that when clients make a (authenticated) request to the results endpoint, they are redirected to the actual file which is stored in a Google CDN location. This should lead the client to strip the auth headers from the request, as otherwise would be a breach of HTTP security best policies.

**How was this tested**
I've built & deployed a Docker image with this version on idfdev, and tested with the following tools:

- topcat (async queries fail with newest Topcat, but his is due to a bug which will be fixed by the author)
- pyvo async queries with CredentialStore authentication)
- pyvo async queries with AuthSession authentication)

**Potential issues**
I've only tested this on idfdev, but we have several RSP operators who are storing results in a slightly different way (S3 in openstack for example). Could this break for their environment?