### PR TITLE
Remove cadc lib not needed & fix starlink conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.4.2'></a>
+## 2.4.2 (2024-07-15)
+
+### Changed
+
+- Remove unneeded cadc-libs
+
+### Fixed
+
+- Conflict between stilts & dali packages
+
 <a id='changelog-2.4.1'></a>
 ## 2.4.1 (2024-07-15)
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,13 @@ war {
 configurations {
     intTestCompile.extendsFrom testImplementation
     intTestRuntime.extendsFrom testRuntimeOnly
+    implementation.exclude group: 'uk.ac.starlink'
 }
 
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
     implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
+    implementation 'org.opencadc:cadc-access-control-identity:[1.0.7,)'
     implementation 'org.opencadc:cadc-adql:1.1.13'
     implementation 'org.opencadc:cadc-dali-pg:0.3.1'
     implementation 'org.opencadc:cadc-log:1.2.1'
@@ -66,9 +68,6 @@ dependencies {
 
     implementation 'com.google.cloud:google-cloud-storage:1.48.0'
     implementation 'org.restlet.jee:org.restlet.ext.servlet:2.0.3'
-    implementation 'org.opencadc:cadc-tap-server:[1.1.5,)'
-    implementation 'org.opencadc:cadc-adql:[1.1.4,)'
-    implementation 'org.opencadc:cadc-access-control-identity:[1.0.7,)'
     implementation 'software.amazon.awssdk:s3:2.17.230'
     implementation 'software.amazon.awssdk:auth:2.17.230'
     implementation 'org.apache.solr:solr-s3-repository:8.11.2'


### PR DESCRIPTION
**Summary**
- Fixed issue where the stils starlink package causes conflicts with dali package with the same name, during TAP_UPLOAD with binary data
- Remove duplicate cadc-libs

**Tests**

_Taplint:_

Expected: Totals: Errors: 97; Warnings: 695; Infos: 158; Summaries: 20; Failures: 3 (on main version)
Actual: Totals: Errors: 97; Warnings: 695; Infos: 158; Summaries: 20; Failures: 3 (tickets/DM-45142)

Errors & warning match between the two (This should eventually be an automated test)

_Notebooks:_

DP02_02_Catalog_Queries_with_TAP (Sucess)
DC2_catalog_access (Sucess)
DP02_13a_Image_Cutout_SciDemo (Sucess)

_Firefly:_

Test DP02 tab with object: 62, -37 (Success)
Test D02 with query: SELECT TOP 10 * FROM dp02_dc2_catalogs.Object (Success)
TAP_UPLOAD Not tested (Not possible atm)