### PR TITLE
Revert uws connection pool settings to release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.4.7'></a>
+## 2.4.7 (2024-07-31)
+
+### Changed
+
+- Revert uws connection pool settings to release 2.3.0
+
 <a id='changelog-2.4.6'></a>
 ## 2.4.6 (2024-07-30)
 

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -41,7 +41,7 @@
               type="javax.sql.DataSource"
               factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
               minEvictableIdleTimeMillis="30000"
-              maxActive="${uws.maxActive}" maxIdle="1" maxWait="20000" initialSize="5" minIdle="1"
+              maxActive="1" maxIdle="1" maxWait="20000" initialSize="1" minIdle="1"
               username="${uws.username}" password="${uws.password}"
               driverClassName="${uws.driverClassName}"
               url="${uws.url}"


### PR DESCRIPTION
**Summary**
There is an issue on prod where TAP does not execute any async queries, which end up being stuck in a "QUEUED" state.

**Version of TAP**
2.3.1

**More details**
https://rubinobs.atlassian.net/browse/DM-45307

**Proposed fix**
Revert  UWS connection pool setting back to what they were pre 2.3.1

**Date observed**
- July 17 2024
- July 12 2024