### PR TITLE
Use our start script as ENTRYPOINT and have that call cadc start script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.4.3'></a>
+## 2.4.3 (2024-07-18)
+
+### Fixed
+
+- Start script now runs as ENTRYPOINT and that triggers the cadc start script.
+- Fixes issue where Datalink manifest was not being fetched to /tmp
+
 <a id='changelog-2.4.2'></a>
 ## 2.4.2 (2024-07-15)
 

--- a/docker/Dockerfile.lsst-tap-service
+++ b/docker/Dockerfile.lsst-tap-service
@@ -12,4 +12,4 @@ RUN chmod +x /usr/local/bin/start.sh
 ADD docker/*.war /usr/share/tomcat/webapps/
 
 # Run the start script to handle the datalink task
-RUN /usr/local/bin/start.sh
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,3 +6,5 @@ if [ -n "$DATALINK_PAYLOAD_URL" ]; then
     curl -L "$DATALINK_PAYLOAD_URL" -o /tmp/datalink_payload.zip
     unzip /tmp/datalink_payload.zip -d /tmp/datalink
 fi
+
+exec /usr/bin/cadc-tomcat-start


### PR DESCRIPTION
**Summary**

There was a bug in the changes made in the previous upgrade to using the cadc-tomcat base image, where the start script was not run correctly. This change modifes the Dockerfile to run our script as an ENTRYPOINT and have that call the underyling /usr/bin/cadc-tomcat-start script.

**Tests**
Tested on dev with the following usage scenarios:
- Run simple select top 10 sync/async queries
- Get some data from ivoa.Obscore and make sure datalinks show up correctly
- Run taplint:
`Totals: Errors: 97; Warnings: 695; Infos: 158; Summaries: 20; Failures: 3`
    The errors & warning are all the expected ones, which should be fixed soon (metadata, missing tables & sync POST bug in topcat)