### PR TITLE
Change accessURL use for /tables to "base"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-2.4.4'></a>
+## 2.4.4 (2024-07-23)
+
+### Changed
+
+- Changed /tables endpoint accessURL to base, this allows us to add the 'lsst-token' to /tables as the security method
+
 <a id='changelog-2.4.3'></a>
 ## 2.4.3 (2024-07-18)
 

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -29,7 +29,7 @@
 
   <capability standardID="ivo://ivoa.net/std/VOSI#tables-1.1">
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.1">
-      <accessURL use="full">https://replace.me.com/api/tap/tables</accessURL>
+      <accessURL use="base">https://replace.me.com/api/tap/tables</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#BasicAA"/>
       <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
       <securityMethod standardID="ivo://ivoa.net/sso#OAuth"/>


### PR DESCRIPTION
**Description**

We use the following authentication mechanism with pyvo:

```
s = requests.Session()
s.headers["Authorization"] = "Bearer " + token
auth = pyvo.auth.authsession.AuthSession()
auth.credentials.set("lsst-token", s)
tap_service = pyvo.dal.TAPService(baseurl=tap_url,
                                  session=auth)
auth.credentials.set("lsst-token", s)
auth.add_security_method_for_url(tap_url, "lsst-token")
auth.add_security_method_for_url(tap_url + "/sync", "lsst-token")
auth.add_security_method_for_url(tap_url + "/async", "lsst-token")
auth.add_security_method_for_url(tap_url + "/tables", "lsst-token")
```
With the updated capabilities we switched to using "full" for as the accessURL use type, however this leads to pyvo not finding the "lsst-token" security method when we make a request to "/tables" because it first checks the `full_urls` set seen here:
https://github.com/astropy/pyvo/blob/main/pyvo/auth/authurls.py#L43
It then finds an entry for "/tables"under full_urls and uses those security methods, ignoring what is in the `base_urls` list.
With this PR this is changed back to "base" which adds it to the `base_urls` and the above snippet works fine.
In the future when we roll out the new capabilities to prod, we should probably switch the above snippet to just:

```
s = requests.Session()
s.headers["Authorization"] = "Bearer " + token
auth = pyvo.auth.authsession.AuthSession()
auth.credentials.set("ivo://ivoa.net/sso#cookie", s)
```


**Jira Ticket**

https://rubinobs.atlassian.net/browse/DM-45354

**Tests**
- Deployed on dev
- Tested a few queries with Firefly and some Notebooks
- Tested with taplint:
` Totals: Errors: 97; Warnings: 695; Infos: 158; Summaries: 20; Failures: 3
`

_Note: Lots of manual testing, need to move to more automated tests soon_