### PR TITLE
Remove cadc-tap log package from logLevelPackages & Add header to log4j.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-# Change log
+	# Change log
 
 lsst-tap-service is versioned with [semver](https://semver.org/). Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
 Find changes for the upcoming release in the project's [changelog.d](https://github.com/lsst-sqre/lsst-tap-service/tree/main/changelog.d/).
 
 <!-- scriv-insert-here -->
+
+<a id='changelog-2.4.6'></a>
+## 2.4.6 (2024-07-30)
+
+### Changed
+
+- Added some cadc packages to log control & add missing header to log4j
 
 <a id='changelog-2.4.5'></a>
 ## 2.4.5 (2024-07-24)

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -1,3 +1,4 @@
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration debug="false">
     <!--Console appender -->
     <appender name="stdout" class="org.apache.log4j.ConsoleAppender">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -19,9 +19,13 @@
             <param-value>
                 ca.nrc.cadc.tap
                 org.opencadc.tap
-                ca.nrc.cadc.log
                 ca.nrc.cadc.rest
                 ca.nrc.cadc.uws
+                ca.nrc.cadc.dali
+                ca.nrc.cadc.cat
+                ca.nrc.cadc.net
+                ca.nrc.cadc.auth
+                ca.nrc.cadc.vosi
             </param-value>
         </init-param>
         <init-param>


### PR DESCRIPTION
Current setup produces a few warnings from the logging servlet, where it complains about a missing header in log4j.xml and a warning about a log message which should not be appearing. The second one is fixed by remove ca.nrc.cadc.log from the logLevelPackages in the web.xml configuration. A Doctype is added to address the first issue.