### PR TITLE
DM-45739: Remove restlet and obsolete maven repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
-    jcenter()
 
     maven {
         url = 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/m2repo'
@@ -67,7 +66,6 @@ dependencies {
     testImplementation 'xmlunit:xmlunit:[1.0,)'
 
     implementation 'com.google.cloud:google-cloud-storage:1.48.0'
-    implementation 'org.restlet.jee:org.restlet.ext.servlet:2.0.3'
     implementation 'software.amazon.awssdk:s3:2.17.230'
     implementation 'software.amazon.awssdk:auth:2.17.230'
     implementation 'org.apache.solr:solr-s3-repository:8.11.2'

--- a/changelog.d/20240813_174428_steliosvoutsinas_DM_45739.md
+++ b/changelog.d/20240813_174428_steliosvoutsinas_DM_45739.md
@@ -1,0 +1,4 @@
+### Removed
+
+- Update jcenter repo (obsolete)
+- Remove  restlet jar


### PR DESCRIPTION
**Summary:**

- Remove jcenter repo as it is obsolete and no longer used by cadc
- Remove org.restlet.jee:org.restlet.ext.servlet:2.0.3 no longer needed