### PR TITLE
Update version of gms to 1.0.14 and fix Dockerfile warning about LABEL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.opencadc:cadc-adql:1.1.13'
     implementation 'org.opencadc:cadc-dali-pg:0.3.1'
     implementation 'org.opencadc:cadc-log:1.2.1'
+    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
     implementation 'org.opencadc:cadc-rest:1.3.20'
     implementation 'org.opencadc:cadc-tap-schema:1.1.32'
     implementation 'org.opencadc:cadc-tap-server:1.1.23'

--- a/changelog.d/20241125_182819_steliosvoutsinas_DM_47788.md
+++ b/changelog.d/20241125_182819_steliosvoutsinas_DM_47788.md
@@ -1,0 +1,11 @@
+<!-- Delete the sections that don't apply -->
+
+### Changed
+
+- Updated version of gms to >=1.0.14
+
+
+### Fixed
+
+- Label warning in Docker build
+

--- a/docker/Dockerfile.lsst-tap-service
+++ b/docker/Dockerfile.lsst-tap-service
@@ -1,6 +1,6 @@
 FROM images.opencadc.org/library/cadc-tomcat:1
 
-LABEL org.opencontainers.image.source="https://github.com/lsst-sqre/lsst-tap-service"
+LABEL org.opencontainers.image.source "https://github.com/lsst-sqre/lsst-tap-service"
 
 RUN dnf update -y && dnf install -y zip unzip
 


### PR DESCRIPTION
Bump version of cadc-gms to >=1.0.14 which uses the new OIDC discovery mechanism (looks for .well-known endpoint).
This requires an update to phalanx to set OIDC issuer to the base url of the RSP.