### PR TITLE
DM-48132: Introduce Binary2 VOTable Serialization and make it default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ war {
 configurations {
     intTestCompile.extendsFrom testImplementation
     intTestRuntime.extendsFrom testRuntimeOnly
-    implementation.exclude group: 'uk.ac.starlink'
+    //implementation.exclude group: 'uk.ac.starlink'
 }
 
 dependencies {
@@ -56,6 +56,10 @@ dependencies {
     implementation 'org.opencadc:cadc-uws:1.0.5'
     implementation 'org.opencadc:cadc-uws-server:1.2.21'
     implementation 'org.opencadc:cadc-vosi:1.4.6'
+    implementation 'uk.ac.starlink:stil:[4.0,5.0)'
+
+    implementation 'uk.ac.starlink:jcdf:[1.2.3,2.0)'
+    implementation 'uk.ac.starlink:stil:[4.0,5.0)'
 
     // Switch out this to use any supported database instead of PostgreSQL.
     // ## START CUSTOM DATABASE ##

--- a/changelog.d/20250114_162646_steliosvoutsinas_DM_48132.md
+++ b/changelog.d/20250114_162646_steliosvoutsinas_DM_48132.md
@@ -1,0 +1,13 @@
+<!-- Delete the sections that don't apply -->
+
+### Added
+
+- ResultSetWriter class, used to write out Binary2 VOTable serialization
+
+### Changed
+
+- Added new Binary2 VOTable serialization, make default. Retain tabledata as an optional format
+
+### Fixed
+
+- Correctly print field metadata

--- a/src/main/java/org/opencadc/tap/impl/MaxRecValidatorImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/MaxRecValidatorImpl.java
@@ -93,7 +93,6 @@ public class MaxRecValidatorImpl extends MaxRecValidator {
 
     @Override
     public Integer validate() {
-        LOGGER.info("");
         if (super.sync) {
             try {
                 // no limits on sync

--- a/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
+++ b/src/main/java/org/opencadc/tap/impl/QServQueryRunner.java
@@ -371,7 +371,7 @@ public class QServQueryRunner implements JobRunner
                     // and restrict to forward only so that client memory usage is minimal since
                     // we are only interested in reading the ResultSet once
 
-		    connection.setAutoCommit(false);
+                    connection.setAutoCommit(false);
                     pstmt = connection.prepareStatement(sql);
                     pstmt.setFetchSize(1000);
                     pstmt.setFetchDirection(ResultSet.FETCH_FORWARD);
@@ -397,7 +397,7 @@ public class QServQueryRunner implements JobRunner
                         tableWriter.write(resultSet, syncOutput.getOutputStream());
                     else
                         tableWriter.write(resultSet, syncOutput.getOutputStream(), maxRows.longValue());
-
+                    
                     t2 = System.currentTimeMillis(); dt = t2 - t1; t1 = t2;
                     diagnostics.add(new Result("diag", URI.create("query:stream:"+dt)));
                 }

--- a/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
@@ -396,6 +396,7 @@ public class ResultSetWriter implements TableWriter<ResultSet> {
             extends SequentialResultSetStarTable {
     	
         public static final String TABLE_NAME_INFO = "TABLE_NAME";
+        public static final String ACTUAL_COLUMN_NAME_INFO = "COLUMN_NAME";
         private final long maxrec_;
         private boolean overflow_;
         private long totalRows = 0;
@@ -468,10 +469,12 @@ public class ResultSetWriter implements TableWriter<ResultSet> {
 	                    ColumnInfo info = columnInfos[i];
 	                    
 	                    DescribedValue tableNameValue = info.getAuxDatumByName(TABLE_NAME_INFO);
+	                    DescribedValue actualColumnValue =  info.getAuxDatumByName(ACTUAL_COLUMN_NAME_INFO);
 	                    if (tableNameValue != null) {
 	                        String tableName = tableNameValue.getValue().toString();
+	                        String actualColName = actualColumnValue.getValue().toString();
 	                        
-	                        if ("access_url".equals(info.getName())) {
+	                        if ("access_url".equals(actualColName)) {
 	                            boolean isObsCore = "ivoa.ObsCore".equals(tableName);
 	                            columns.put(i, isObsCore);
 	                            log.debug("Found access_url column at index " + i + 

--- a/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
@@ -1,0 +1,717 @@
+package org.opencadc.tap.impl;
+
+import ca.nrc.cadc.dali.tables.TableWriter;
+import ca.nrc.cadc.dali.tables.votable.GroupElement;
+import ca.nrc.cadc.dali.tables.votable.ParamElement;
+import ca.nrc.cadc.dali.tables.votable.VOTableField;
+import ca.nrc.cadc.dali.tables.votable.VOTableGroup;
+import ca.nrc.cadc.dali.tables.votable.VOTableInfo;
+import ca.nrc.cadc.dali.tables.votable.VOTableParam;
+import ca.nrc.cadc.dali.tables.votable.VOTableResource;
+import ca.nrc.cadc.dali.util.Format;
+import ca.nrc.cadc.dali.util.FormatFactory;
+import ca.nrc.cadc.xml.ContentConverter;
+import ca.nrc.cadc.xml.IterableContent;
+import ca.nrc.cadc.xml.MaxIterations;
+import uk.ac.starlink.table.ColumnInfo;
+import uk.ac.starlink.table.DescribedValue;
+import uk.ac.starlink.table.RowSequence;
+import uk.ac.starlink.table.WrapperRowSequence;
+import uk.ac.starlink.table.jdbc.SequentialResultSetStarTable;
+import uk.ac.starlink.votable.DataFormat;
+import uk.ac.starlink.votable.VOSerializer;
+import uk.ac.starlink.votable.VOTableVersion;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.output.XMLOutputter;
+
+/**
+ * ResultSet to VOTable writer.
+ *
+ * @author stvoutsin
+ */
+public class ResultSetWriter implements TableWriter<ResultSet> {
+
+    private static final Logger log = Logger.getLogger(ResultSetWriter.class);
+    private static final String BASE_URL = System.getProperty("base_url");
+
+    public static final String CONTENT_TYPE = "application/x-votable+xml";
+    public static final String CONTENT_TYPE_ALT = "text/xml";
+
+    // VOTable Version number.
+    public static final String VOTABLE_VERSION = "1.4";
+
+    // Uri to the XML schema.
+    public static final String XSI_SCHEMA = "http://www.w3.org/2001/XMLSchema-instance";
+
+    // Uri to the VOTable schema.
+    public static final String VOTABLE_11_NS_URI = "http://www.ivoa.net/xml/VOTable/v1.1";
+    public static final String VOTABLE_12_NS_URI = "http://www.ivoa.net/xml/VOTable/v1.2";
+    public static final String VOTABLE_13_NS_URI = "http://www.ivoa.net/xml/VOTable/v1.3";
+    public static final String VOTABLE_14_NS_URI = "http://www.ivoa.net/xml/VOTable/v1.4";
+
+    private FormatFactory formatFactory;
+    private String mimeType;
+    private DataFormat dfmt_;
+    private VOTableVersion version_;
+    private long maxrec_;
+    private List<VOTableInfo> infos;
+    private List<VOTableResource> resources;
+    private ColumnInfo[] columns;
+    private long totalRows = 0;
+
+    /**
+     * Get the total number of rows processed.
+     *
+     * @return the number of rows written
+     */
+    public long getRowCount() {
+        return totalRows;
+    }
+    
+    /**
+     * Default constructor.
+     */
+    public ResultSetWriter() {
+        this(null, uk.ac.starlink.votable.DataFormat.BINARY2, VOTableVersion.V14, -1);
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param  mimeType selects the mimetype string
+     * @param  dfmt  selects VOTable serialization format
+     *               (TABLEDATA, BINARY, BINARY2, FITS)
+     * @param  version  selects VOTable version
+     * @param  maxrec   maximum record count before overflow;
+     *                  negative value means no limit
+     */
+    public ResultSetWriter( String mimeType, DataFormat dfmt, VOTableVersion version, long maxrec ) {
+    	this.mimeType = mimeType;
+    	this.dfmt_ = dfmt;
+    	this.version_ = version;
+    	this.maxrec_ = maxrec;
+        this.infos = new ArrayList<>();
+        this.resources = new ArrayList<>();
+        this.columns = null;
+    }
+
+    
+    /**
+     * Get the Content-Type for the VOTable.
+     *
+     * @return VOTable Content-Type.
+     */
+    @Override
+    public String getContentType() {
+        if (mimeType == null) {
+            return CONTENT_TYPE;
+        }
+
+        return mimeType;
+    }
+
+    public List<VOTableResource> getResources() {
+        return resources;
+    }
+
+    /**
+     * Get the list of VOTable infos.
+     *
+     * @return List of VOTableInfo objects
+     */
+    public List<VOTableInfo> getInfos() {
+        return infos;
+    }
+    
+    public ColumnInfo[] getColumns() {
+        return columns;
+    }
+    
+    /**
+     * Set the list of VOTable infos.
+     *
+     * @param infos List of VOTableInfo objects
+     */
+    public void setInfos(List<VOTableInfo> infos) {
+        this.infos = infos;
+    }
+    
+    public void setColumns(ColumnInfo[] columns) {
+        this.columns = columns;
+    }
+    
+    
+    /**
+     * Set the resources of the VOTable.
+     *
+     * @param resources List of VOTableResource objects
+     */
+    public void setResources(List<VOTableResource> resources) {
+        this.resources = resources;
+    }
+    
+    /**
+     * Add a single VOTable info.
+     *
+     * @param info VOTableInfo object to add
+     */
+    public void addInfo(VOTableInfo info) {
+        if (info != null) {
+            this.infos.add(info);
+        }
+    }
+
+    
+    /**
+     * Add a single VOTableResource object.
+     *
+     * @param resource VOTableResource object to add
+     */
+    public void addResource(VOTableResource resource) {
+        if (resource != null) {
+            this.resources.add(resource);
+        }
+    }  
+    /**
+     * Get error content type
+     */
+    public String getErrorContentType() {
+        return getContentType();
+    }
+
+    /**
+     * Get the extension for the VOTable.
+     *
+     * @return VOTable extension.
+     */
+    @Override
+    public String getExtension() {
+        return "xml";
+    }
+
+    @Override
+    public void setFormatFactory(FormatFactory formatFactory) {
+        this.formatFactory = formatFactory;
+    }
+
+    /**
+     * Write the ResultSet to the specified OutputStream.
+     *
+     * @param resultSet ResultSet object to write.
+     * @param ostream OutputStream to write to.
+     * @throws IOException if problem writing to OutputStream.
+     */
+    @Override
+    public void write(ResultSet resultSet, OutputStream ostream)
+            throws IOException {
+        write(resultSet, ostream, Long.MAX_VALUE);
+    }
+
+    /**
+     * Write the ResultSet to the specified OutputStream, only writing maxrec rows.
+     * If the VOTable contains more than maxrec rows, appends an INFO element with
+     * name="QUERY_STATUS" value="OVERFLOW" to the VOTable.
+     *
+     * @param resultSet ResultSet object to write.
+     * @param ostream OutputStream to write to.
+     * @param maxrec maximum number of rows to write.
+     * @throws IOException if problem writing to OutputStream.
+     */
+    @Override
+    public void write(ResultSet resultSet, OutputStream ostream, Long maxrec)
+            throws IOException {
+        Writer writer = new BufferedWriter(new OutputStreamWriter(ostream, "UTF-8"));
+        write(resultSet, writer, maxrec);
+    }
+    
+    /**
+     * Write the ResultSet to the specified Writer.
+     *
+     * @param resultSet ResultSet object to write.
+     * @param writer Writer to write to.
+     * @throws IOException if problem writing to the writer.
+     */
+    @Override
+    public void write(ResultSet resultSet, Writer writer)
+            throws IOException {
+        write(resultSet, writer, Long.MAX_VALUE);
+    }
+
+    /**
+     * Write the ResultSet to the specified Writer, only writing maxrec rows.
+     * If the ResultSet contains more than maxrec rows, appends an INFO element with
+     * name="QUERY_STATUS" value="OVERFLOW" to the VOTable.
+     *
+     * @param resultSet ResultSet object to write.
+     * @param writer Writer to write to.
+     * @param maxrec maximum number of rows to write.
+     * @throws IOException if problem writing to the writer.
+     */
+    @Override
+    public void write(ResultSet resultSet, Writer writer, Long maxrec)
+            throws IOException {
+        if (formatFactory == null) {
+            this.formatFactory = new FormatFactory();
+        }
+        writeImpl(resultSet, writer, maxrec);
+    }
+    
+    /**
+     * Write the Throwable to a VOTable, creating an INFO element with
+     * name="QUERY_STATUS" value="ERROR" and setting the stacktrace as
+     * the INFO text.
+     *
+     * @param thrown Throwable to write.
+     * @param output OutputStream to write to.
+     * @throws IOException if problem writing to the stream.
+     */
+    public void write(Throwable thrown, OutputStream output)
+            throws IOException {
+        Document document = createDocument();
+        Element root = document.getRootElement();
+        Namespace namespace = root.getNamespace();
+
+        // Create the RESOURCE element and add to the VOTABLE element.
+        Element resource = new Element("RESOURCE", namespace);
+        resource.setAttribute("type", "results");
+        root.addContent(resource);
+
+        // Create the INFO element and add to the RESOURCE element.
+        Element info = new Element("INFO", namespace);
+        info.setAttribute("name", "QUERY_STATUS");
+        info.setAttribute("value", "ERROR");
+        info.setText(getThrownExceptions(thrown));
+        resource.addContent(info);
+
+        // Write out the VOTABLE.
+        XMLOutputter outputter = new XMLOutputter();
+        outputter.setFormat(org.jdom2.output.Format.getPrettyFormat());
+        outputter.output(document, output);
+    }
+    
+    /**
+     * Writes a result set to an output stream as a VOTable.
+     *
+     * @param   resultSet  ResultSet
+     * @param   writer  Writer
+     * @param   maxrec Maximum number of rows
+     */
+    protected void writeImpl(ResultSet resultSet, Writer writer, Long maxrec)
+            throws IOException {
+        log.debug("write, maxrec=" + maxrec);
+
+        
+        try (BufferedWriter out = (writer instanceof BufferedWriter)
+                ? (BufferedWriter) writer
+                : new BufferedWriter(writer)) {
+
+            LimitedResultSetStarTable table;
+            try {
+                table = new LimitedResultSetStarTable(this.getColumns(), resultSet, maxrec);
+            } catch (SQLException e) {
+                throw new IOException("Error processing ResultSet: " + e.getMessage(), e);
+            }
+	
+	        /* Prepares the object that will do the serialization work. */
+	        VOSerializer voser =
+	            VOSerializer.makeSerializer( dfmt_, version_, table );
+
+	        /* Write header. */
+	        out.write( "<VOTABLE"
+	                 + VOSerializer.formatAttribute( "version",
+	                                                 version_.getVersionNumber() )
+	                 + VOSerializer.formatAttribute( "xmlns",
+	                                                 version_.getXmlNamespace() )
+	                 + ">" );
+	        out.newLine();
+	        out.write( "<RESOURCE>" );
+	        out.newLine();
+	        
+            XMLOutputter outputter = new XMLOutputter();
+            outputter.setFormat(org.jdom2.output.Format.getPrettyFormat());
+            
+	        // Write all info elements
+	        for (VOTableInfo info : infos) {
+	        	Element infoElement = new Element("INFO");
+	            infoElement.setAttribute("name", info.getName());
+	            infoElement.setAttribute("value", info.getValue());
+	            outputter.output(infoElement, out);
+	            out.newLine();
+	        }
+	        
+	        /* Write table element. */
+	        voser.writeInlineTableElement( out );
+	
+	        /* Check for overflow and write INFO if required. */
+	        if ( table.lastSequenceOverflowed() ) {
+	            out.write( "<INFO name='QUERY_STATUS' value='OVERFLOW'/>" );
+	            out.newLine();
+	        }
+
+	        /* Write footer. */
+	        out.write( "</RESOURCE>" );
+	        out.newLine();
+	        for (VOTableResource resource : resources) {
+	        	Element r = createResource(resource, null);
+	            outputter.output(r, out);
+	            out.newLine();
+	        }
+	        out.write( "</VOTABLE>" );
+	        out.newLine();
+	        out.flush();
+	        
+	        this.totalRows = table.getTotalRows();
+	
+		}
+    }
+
+    /**
+     * StarTable implementation which is based on a ResultSet, and which
+     * is limited to a fixed number of rows when its row iterator is used.
+     * Note this implementation is OK for one-pass table output handlers
+     * like VOTable, but won't work for ones which require two passes
+     * such as FITS (which needs row count up front).
+     */
+    private static class LimitedResultSetStarTable
+            extends SequentialResultSetStarTable {
+    	
+        public static final String TABLE_NAME_INFO = "TABLE_NAME";
+        private final long maxrec_;
+        private boolean overflow_;
+        private long totalRows = 0;
+		private ColumnInfo[] columnInfos;
+
+        /**
+         * Constructor.
+         *
+         * @param   rset  result set supplying the data
+         * @param   maxrec   maximum number of rows that will be iterated over;
+         *                   negative value means no limit
+         */
+        LimitedResultSetStarTable(ColumnInfo[] colInfos, ResultSet rset, long maxrec )
+                throws SQLException {
+            super( rset );
+            maxrec_ = maxrec;
+			columnInfos = colInfos;
+        }
+        
+        /**
+         * Get the row count 
+         */
+        public long getTotalRows() {
+           return totalRows;
+        }
+
+        /**
+         * Provides column information for a specified index.
+         *
+         * @param  colInd  index of the column to describe
+         * @return  metadata object describing this column
+         */
+        @Override
+        public ColumnInfo getColumnInfo(final int colInd) {
+            return columnInfos[colInd];
+        }
+            
+        /**
+         * Indicates whether the last row sequence dispensed by
+         * this table's getRowSequence method was truncated at maxrec rows.
+         *
+         * @return   true iff the last row sequence overflowed
+         */
+        public boolean lastSequenceOverflowed() {
+            return overflow_;
+        }
+        
+        /**
+         * A RowSequence wrapper that modifies obscore access URLs in result sets.
+         * This class intercepts access_url column values and rewrites them to use a different base URL
+         *
+         * @throws RuntimeException if URL rewriting fails due to malformed URLs
+         */
+        private static class ModifiedLimitRowSequence extends WrapperRowSequence {
+            private final Map<Integer, Boolean> accessUrlColumns;
+
+            ModifiedLimitRowSequence(RowSequence baseSeq, ColumnInfo[] columnInfos) {
+                super(baseSeq);
+                this.accessUrlColumns = findAccessUrlColumns(columnInfos);
+            }
+            
+            /**
+             * Find all access_url columns and determine if they belong to ivoa.ObsCore.
+             * Returns a map of column indices to boolean indicating if they should be modified.
+             */
+            private static Map<Integer, Boolean> findAccessUrlColumns(ColumnInfo[] columnInfos) {
+                Map<Integer, Boolean> columns = new HashMap<>();
+                try {
+	                for (int i = 0; i < columnInfos.length; i++) {
+	                    ColumnInfo info = columnInfos[i];
+	                    
+	                    DescribedValue tableNameValue = info.getAuxDatumByName(TABLE_NAME_INFO);
+	                    if (tableNameValue != null) {
+	                        String tableName = tableNameValue.getValue().toString();
+	                        
+	                        if ("access_url".equals(info.getName())) {
+	                            boolean isObsCore = "ivoa.ObsCore".equals(tableName);
+	                            columns.put(i, isObsCore);
+	                            log.debug("Found access_url column at index " + i + 
+	                                    " for table " + tableName + 
+	                                    (isObsCore ? " (will modify URLs)" : " (won't modify URLs)"));
+	                        }
+	                    }
+	                }
+                } catch (NullPointerException ex) {
+                	log.debug("Error while trying to find access_url columns");
+                }
+
+                return columns;
+            }
+            
+            /**
+             * Returns the value from a single cell, modifying it if it's a URL that needs to be rewritten.
+             *
+             * @param  icol  the column index
+             * @return  the cell contents
+             */
+            @Override
+            public Object getCell(int icol) throws IOException {
+                Object value = super.getCell(icol);
+                if (shouldModifyUrl(icol, value)) {
+                    return modifyAccessUrl((String) value);
+                }
+                return value;
+            }
+            
+            /**
+             * Returns values from an entire row, modifying any URLs that need to be rewritten.
+             *
+             * @return  array containing values for the current row
+             */
+            @Override
+            public Object[] getRow() throws IOException {
+                Object[] row = super.getRow();
+                for (Map.Entry<Integer, Boolean> entry : accessUrlColumns.entrySet()) {
+                    int index = entry.getKey();
+                    if (index >= 0 && index < row.length && 
+                        shouldModifyUrl(index, row[index])) {
+                        row[index] = modifyAccessUrl((String) row[index]);
+                    }
+                }
+                return row;
+            }
+            
+            /**
+             * Determines whether a value at a given index should have its URL modified.
+             *
+             * @param  columnIndex  index of the column containing the value
+             * @param  value  the value to check
+             * @return  true if the value should have its URL modified
+             */
+            private boolean shouldModifyUrl(int columnIndex, Object value) {
+                return value instanceof String && 
+                       accessUrlColumns.containsKey(columnIndex) && 
+                       accessUrlColumns.get(columnIndex) && 
+                       value != null;
+            }
+
+            /**
+             * Modifies a URL to use the base URL while preserving the path.
+             *
+             * @param  url  the original URL to modify, or null
+             * @return  the modified URL, or null if the input was null
+             * @throws RuntimeException if URL parsing or rewriting fails
+             */
+            private String modifyAccessUrl(String url) {
+                if (url != null) {
+	            	String s = (String) url;
+	            	try {
+	                    URL orig = new URL(s);
+	            	    URL base_url = new URL(BASE_URL);
+	            	    URL rewritten = new URL(orig.getProtocol(), base_url.getHost(), orig.getFile());
+	            	    log.debug( "Rewritten URL: " + rewritten.toExternalForm());
+	
+	            	    return rewritten.toExternalForm();
+	            	} catch (MalformedURLException ex) {
+	                        throw new RuntimeException("BUG: Failed to rewrite URL: " + s, ex);
+	                    }
+	                }
+                return url;
+            }
+        }
+        
+        /**
+         * Returns a row sequence that may be limited to a maximum number of rows.
+         * Creates a sequence that wraps the underlying ResultSet, applies URL modifications
+         * if needed, and enforces any row limit specified by maxrec_.
+         *
+         * @return  a row sequence, possibly truncated at maxrec_ rows
+         * @throws IOException if there is an error reading from the base sequence
+         */
+        @Override
+        public RowSequence getRowSequence() throws IOException {
+            overflow_ = false;
+            totalRows = 0;
+            RowSequence baseSeq = super.getRowSequence();
+            baseSeq = new ModifiedLimitRowSequence(baseSeq, columnInfos);
+            
+            if (maxrec_ < 0 || maxrec_ == Long.MAX_VALUE) {
+                return new WrapperRowSequence(baseSeq) {
+                    @Override
+                    public boolean next() throws IOException {
+                        boolean hasNext = super.next();
+                        if (hasNext) {
+                            totalRows++;
+                        }
+                        return hasNext;
+                    }
+                };            
+            } else {
+                return new WrapperRowSequence( baseSeq ) {
+                    long irow = -1;
+                    @Override
+                    public boolean next() throws IOException {
+                        irow++;
+                        if ( irow < maxrec_ ) {
+                            boolean hasNext = super.next();
+                            if (hasNext) {
+                                totalRows++;
+                            }
+                            return hasNext;
+                        }
+                        if ( irow == maxrec_ ) {
+                        	log.debug("Overflow reached while processing rows!");
+                            overflow_ = super.next();
+                        }
+                        return false;
+                    }
+                };
+            }
+        }
+    }
+    
+    /**
+     * Creates a JDOM Element representing a VOTable RESOURCE from a VOTableResource object.
+     * Converts the VOTableResource into XML format, including all its attributes, description,
+     * INFO elements, parameters, and groups.
+     *
+     * @param  votResource  the VOTableResource to convert
+     * @param  namespace   the XML namespace to use, may be null
+     * @return  JDOM Element containing the XML representation of the resource
+     */
+    private Element createResource(VOTableResource votResource, Namespace namespace) {
+        // Create the RESOURCE element and add to the VOTABLE element.
+        Element resource = new Element("RESOURCE", namespace);
+
+        resource.setAttribute("type", votResource.getType());
+        log.debug("wrote resource.type: " + votResource.getType());
+
+        if (votResource.id != null) {
+            resource.setAttribute("ID", votResource.id);
+        }
+
+        if (votResource.getName() != null) {
+            resource.setAttribute("name", votResource.getName());
+        }
+
+        if (votResource.utype != null) {
+            resource.setAttribute("utype", votResource.utype);
+        }
+
+        // Create the DESCRIPTION element and add to RESOURCE element.
+        if (votResource.description != null) {
+            Element description = new Element("DESCRIPTION", namespace);
+            description.setText(votResource.description);
+            resource.addContent(description);
+        }
+
+        // Create the INFO element and add to the RESOURCE element.
+        for (VOTableInfo in : votResource.getInfos()) {
+            Element info = new Element("INFO", namespace);
+            info.setAttribute("name", in.getName());
+            info.setAttribute("value", in.getValue());
+            if (in.content != null) {
+                info.setText(in.content);
+            }
+            resource.addContent(info);
+        }
+        log.debug("wrote resource.info: " + votResource.getInfos().size());
+
+        for (VOTableParam param : votResource.getParams()) {
+            resource.addContent(new ParamElement(param, namespace));
+        }
+        log.debug("wrote resource.param: " + votResource.getParams().size());
+
+        for (VOTableGroup vg : votResource.getGroups()) {
+            resource.addContent(new GroupElement(vg, namespace));
+        }
+
+        return resource;
+    }
+    
+    /**
+     * Builds a empty VOTable document with the appropriate namespaces and
+     * attributes.
+     *
+     * @return VOTable document.
+     */
+    protected Document createDocument() {
+        // the root VOTABLE element
+        Namespace vot = Namespace.getNamespace(VOTABLE_14_NS_URI);
+        Namespace xsi = Namespace.getNamespace("xsi", XSI_SCHEMA);
+        Element votable = new Element("VOTABLE", vot);
+        votable.setAttribute("version", VOTABLE_VERSION);
+        votable.addNamespaceDeclaration(xsi);
+
+        Document document = new Document();
+        document.addContent(votable);
+
+        return document;
+    }
+
+    /**
+     * Builds a string containing all exception messages from a throwable and its causes.
+     *
+     * @param  thrown  the throwable to process
+     * @return  space-separated string of all exception messages in the chain
+     */
+    private String getThrownExceptions(Throwable thrown) {
+        StringBuilder sb = new StringBuilder();
+        if (thrown.getMessage() == null) {
+            sb.append("");
+        } else {
+            sb.append(thrown.getMessage());
+        }
+        while (thrown.getCause() != null) {
+            thrown = thrown.getCause();
+            sb.append(" ");
+            if (thrown.getMessage() == null) {
+                sb.append("");
+            } else {
+                sb.append(thrown.getMessage());
+            }
+        }
+        return sb.toString();
+    }
+
+
+}

--- a/src/main/java/org/opencadc/tap/impl/RubinFormatFactory.java
+++ b/src/main/java/org/opencadc/tap/impl/RubinFormatFactory.java
@@ -23,7 +23,7 @@ public class RubinFormatFactory extends OracleFormatFactory {
             // ivoa.ObsCore
             if ("ivoa.ObsCore".equalsIgnoreCase(columnDesc.tableName)) {
                 if ("access_url".equalsIgnoreCase(columnDesc.getColumnName())) {
-	            log.info("getClobFormat called for access_url");
+                    log.info("getClobFormat called for access_url");
                     return new RubinURLFormat();
                 }
             }

--- a/src/main/java/org/opencadc/tap/impl/RubinTableWriter.java
+++ b/src/main/java/org/opencadc/tap/impl/RubinTableWriter.java
@@ -129,6 +129,7 @@ public class RubinTableWriter implements TableWriter
 
     private static final Logger log = Logger.getLogger(RubinTableWriter.class);
     public static final String TABLE_NAME_INFO = "TABLE_NAME";
+    public static final String ACTUAL_COLUMN_NAME_INFO = "COLUMN_NAME";
 
     private static final String FORMAT = "RESPONSEFORMAT";
     private static final String FORMAT_ALT = "FORMAT";
@@ -415,9 +416,8 @@ public class RubinTableWriter implements TableWriter
             String fullColumnName = resultCol.tableName + "_" + resultCol.getColumnName();
             columnNames.add(fullColumnName.replace(".", "_"));
             listIndex++;
-            
             // Generate a ColumnInfo list, to be used by ResultSetWriter for generating the field metadata
-            ColumnInfo colInfo = new ColumnInfo(resultCol.getColumnName(), getDatatypeClass(resultCol.getDatatype(), newField.getArraysize()), newField.description);
+            ColumnInfo colInfo = new ColumnInfo(resultCol.getName(), getDatatypeClass(resultCol.getDatatype(), newField.getArraysize()), newField.description);
     	    colInfo.setUCD(resultCol.ucd);
     	    colInfo.setUtype(resultCol.utype);	
     	    colInfo.setUnitString(resultCol.unit);
@@ -425,9 +425,13 @@ public class RubinTableWriter implements TableWriter
     	    colInfo.setAuxDatum(new DescribedValue(VOStarTable.ID_INFO, newField.id));
     	    colInfo.setAuxDatum(new DescribedValue(new DefaultValueInfo(TABLE_NAME_INFO, String.class),
                     resultCol.tableName));
-            columnInfoList.add(colInfo);
+    	    colInfo.setAuxDatum(new DescribedValue(new DefaultValueInfo(ACTUAL_COLUMN_NAME_INFO, String.class),
+                    resultCol.getColumnName()));
+
+    	    columnInfoList.add(colInfo);
 
         }
+        
         ColumnInfo[] columnInfoArray = columnInfoList.toArray(new ColumnInfo[0]);
 
         List<String> serviceIDs = determineDatalinks(columnNames);


### PR DESCRIPTION
## Description
Introduce a Binary2 VOTable serialization to the RSP TAP services, enabled by default instead of TableData. Maintain the ability to request TableData format explicitly which works by specifying the format in the TAP request. 
This change improves performance by using a more efficient serialization format.

## Changes

### Modified RubinTableWriter class
- Added support for distinguishing between VOTABLE (Binary2) and VOTABLE-TD formats
- Updated format initialization to handle VOTABLE-TD format separately
- Updated row count tracking to properly handle all formats

### Added new ResultSetWriter class
- Implements table writing for Binary2 VOTable format
- Supports proper handling of table metadata including:
  - Column information preservation
  - URL rewriting for ObsCore access_url fields
  - Row count tracking
  - Overflow detection
- Handles maxrec limits correctly

## Testing
- Verified default format produces Binary2 serialization
- Confirmed TableData format still works when explicitly requested
- Tested URL rewriting functionality
- Verified row count accuracy
- Tested with various MAXREC limits
- Validated output against VOTable schema

## Usage
Default behavior remains unchanged from user perspective. To explicitly request TableData format:

Using pyvo:
```
tap_service.run_async("SELECT TOP 5 * FROM TAP_SCHEMA.tables",
                                   FORMAT="application/x-votable+xml;serialization=TABLEDATA")
```