### PR TITLE
DM-48908: Fix Rubin Table writes to work with newer version of cadc-dali

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,23 +6,6 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
-
-    //maven {
-    //    url = 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/m2repo'
-    //}
-
-    // To obtain access to the Oracle Maven repository, put your credentials into environment variables:
-    // - MAVEN_ORACLE_USERNAME
-    // - MAVEN_ORACLE_PASSWORD
-    //
-    // maven {
-    //    name 'maven.oracle.com'
-    //    url 'https://maven.oracle.com'
-    //    credentials {
-    //        username "${System.env.MAVEN_ORACLE_USERNAME}"
-    //        password "${System.env.MAVEN_ORACLE_PASSWORD}"
-    //    }
-    // }
 }
 
 group = 'org.opencadc'
@@ -42,22 +25,23 @@ configurations {
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
     implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
-    implementation 'org.opencadc:cadc-access-control-identity:[1.0.7,)'
-    implementation 'org.opencadc:cadc-adql:1.1.13'
-    implementation 'org.opencadc:cadc-dali-pg:0.3.1'
-    implementation 'org.opencadc:cadc-log:1.2.1'
-    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
-    implementation 'org.opencadc:cadc-rest:1.3.20'
-    implementation 'org.opencadc:cadc-tap-schema:1.1.32'
-    implementation 'org.opencadc:cadc-tap-server:1.1.23'
-    implementation 'org.opencadc:cadc-tap-server-pg:1.0.5'
-    implementation 'org.opencadc:cadc-tap-server-oracle:1.2.11'
-    implementation 'org.opencadc:cadc-util:1.11.2'
-    implementation 'org.opencadc:cadc-uws:1.0.5'
-    implementation 'org.opencadc:cadc-uws-server:1.2.21'
-    implementation 'org.opencadc:cadc-vosi:1.4.6'
-    implementation 'uk.ac.starlink:stil:[4.0,5.0)'
 
+    implementation 'org.opencadc:cadc-access-control-identity:[1.0.7,)'
+    implementation 'org.opencadc:cadc-adql:[1.1.13,)'
+    implementation 'org.opencadc:cadc-dali-pg:0.3.1'
+    implementation 'org.opencadc:cadc-log:[1.2.1,)'
+    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
+    implementation 'org.opencadc:cadc-rest:[1.3.20,)'
+    implementation 'org.opencadc:cadc-tap-schema:1.1.33'
+    implementation 'org.opencadc:cadc-tap-server:1.1.24'
+    implementation 'org.opencadc:cadc-tap-server-pg:1.1.0'
+    implementation 'org.opencadc:cadc-tap-server-oracle:1.2.11'
+    implementation 'org.opencadc:cadc-util:[1.11.2,)'
+    implementation 'org.opencadc:cadc-uws:[1.0.5,)'
+    implementation 'org.opencadc:cadc-uws-server:[1.2.21,)'
+    implementation 'org.opencadc:cadc-vosi:[1.4.6,)'
+
+    implementation 'uk.ac.starlink:stil:[4.0,5.0)'
     implementation 'uk.ac.starlink:jcdf:[1.2.3,2.0)'
     implementation 'uk.ac.starlink:stil:[4.0,5.0)'
 

--- a/changelog.d/20250212_150652_steliosvoutsinas_DM_48908.md
+++ b/changelog.d/20250212_150652_steliosvoutsinas_DM_48908.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Fixed
+
+- Fix Rubin Table writes to work with newer version of cadc-dali

--- a/src/main/java/org/opencadc/tap/impl/ALMATableServlet.java
+++ b/src/main/java/org/opencadc/tap/impl/ALMATableServlet.java
@@ -85,7 +85,11 @@ public class ALMATableServlet extends TableServlet {
     private static final Logger log = Logger.getLogger(ALMATableServlet.class);
 
     private final static String TAPDS_NAME = "jdbc/tapuser";
-
+    
+    /**
+     * Default constructor for ALMATableServlet.
+     * 
+     */
     public ALMATableServlet() { }
 
     @Override

--- a/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
@@ -70,6 +70,7 @@
 package org.opencadc.tap.impl;
 
 import ca.nrc.cadc.tap.AdqlQuery;
+import ca.nrc.cadc.tap.parser.PgsphereDeParser;
 import ca.nrc.cadc.tap.parser.converter.TableNameConverter;
 import ca.nrc.cadc.tap.parser.converter.TableNameReferenceConverter;
 import ca.nrc.cadc.tap.parser.converter.TopConverter;
@@ -99,6 +100,7 @@ public class AdqlQueryImpl extends AdqlQuery
     public AdqlQueryImpl()
     {
         super();
+        setDeparserImpl(PgsphereDeParser.class);
     }
 
     @Override
@@ -133,4 +135,5 @@ public class AdqlQueryImpl extends AdqlQuery
         super.navigatorList.add(new SelectNavigator(new ExpressionNavigator(), tnrc, tnc));
         super.navigatorList.add(new QServRegionConverter(new ExpressionNavigator(), new ReferenceNavigator(), new FromItemNavigator()));
     }
+
 }

--- a/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/AdqlQueryImpl.java
@@ -92,6 +92,10 @@ public class AdqlQueryImpl extends AdqlQuery
 {
     private static Logger log = Logger.getLogger(AdqlQueryImpl.class);
 
+    /**
+     * Default constructor for AdqlQueryImpl.
+     * 
+     */
     public AdqlQueryImpl()
     {
         super();

--- a/src/main/java/org/opencadc/tap/impl/CapGetAction.java
+++ b/src/main/java/org/opencadc/tap/impl/CapGetAction.java
@@ -113,6 +113,10 @@ public class CapGetAction extends RestAction {
      */
     protected boolean doTransform = true;
     
+    /**
+     * Default constructor for CapGetAction.
+     * 
+     */
     public CapGetAction() {
         super();
     }

--- a/src/main/java/org/opencadc/tap/impl/CapInitAction.java
+++ b/src/main/java/org/opencadc/tap/impl/CapInitAction.java
@@ -89,7 +89,10 @@ import org.apache.log4j.Logger;
  */
 public class CapInitAction extends InitAction {
     private static final Logger log = Logger.getLogger(CapInitAction.class);
-
+    /**
+     * Default constructor for CapInitAction.
+     * 
+     */
     public CapInitAction() { 
         super();
     }

--- a/src/main/java/org/opencadc/tap/impl/MaxRecValidatorImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/MaxRecValidatorImpl.java
@@ -83,7 +83,9 @@ public class MaxRecValidatorImpl extends MaxRecValidator {
     private static final Integer DEFAULT_LIMIT = 1000;
     private static final Integer MAX_LIMIT = 10000;
 
-
+    /**
+     * MaxRecValidatorImpl Constructor
+     */
     public MaxRecValidatorImpl() {
         super();
         setDefaultValue(DEFAULT_LIMIT);

--- a/src/main/java/org/opencadc/tap/impl/QServCircle.java
+++ b/src/main/java/org/opencadc/tap/impl/QServCircle.java
@@ -10,6 +10,10 @@ import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 
 import org.apache.log4j.Logger;
 
+/**
+ * QServCircle class
+ *
+ */
 public class QServCircle extends Function implements QServRegion
 {
     private static final Logger log = Logger.getLogger(QServCircle.class);
@@ -18,7 +22,14 @@ public class QServCircle extends Function implements QServRegion
     private Expression ra;
     private Expression dec;
     private Expression radius;
-
+    
+    /**
+     * QServCircle constructor
+     * @param coordsys Coordsys
+     * @param ra ra
+     * @param dec dec
+     * @param radius radius
+     */
     public QServCircle(Expression coordsys, Expression ra, Expression dec, Expression radius)
     {
         this.coordsys = coordsys;
@@ -26,22 +37,38 @@ public class QServCircle extends Function implements QServRegion
         this.dec = dec;
         this.radius = radius;
     }
-
+    
+    /**
+     * Method to get ra
+     * @return the ra expression object
+     */
     public Expression getRA()
     {
         return ra;
     }
 
+    /**
+     * Method to get dec
+     * @return the declination expression object
+     */
     public Expression getDec()
     {
         return dec;
     }
-
+    
+    /**
+     * Method to get radius
+     * @return the radius expression object
+     */
     public Expression getRadius()
     {
         return radius;
     }
 
+    /**
+     * Get point in region
+     * @return The points expression
+     */
     public Expression pointInRegion(QServPoint point)
     {
         List<Expression> params = new ArrayList<Expression>();

--- a/src/main/java/org/opencadc/tap/impl/QServPoint.java
+++ b/src/main/java/org/opencadc/tap/impl/QServPoint.java
@@ -5,6 +5,10 @@ import net.sf.jsqlparser.expression.Function;
 
 import org.apache.log4j.Logger;
 
+/**
+ * QServPoint method
+ * 
+ */
 public class QServPoint extends Function
 {
     private static final Logger log = Logger.getLogger(QServPoint.class);
@@ -12,17 +16,28 @@ public class QServPoint extends Function
     private Expression ra;
     private Expression dec;
 
+    /**
+     * QServPoint constructor
+     */
     public QServPoint(Expression coordsys, Expression ra, Expression dec)
     {
         this.ra = ra;
         this.dec = dec;
     }
 
+    /**
+     * Method to get RA
+     * @return The ra expression
+     */
     public Expression getRA()
     {
         return ra;
     }
 
+    /**
+     * Method to get Declination
+     * @return The dec expression
+     */
     public Expression getDec()
     {
         return dec;

--- a/src/main/java/org/opencadc/tap/impl/QServPolygon.java
+++ b/src/main/java/org/opencadc/tap/impl/QServPolygon.java
@@ -12,6 +12,10 @@ import org.apache.log4j.Logger;
 
 import org.opencadc.tap.impl.QServRegion;
 
+/**
+ * QServ polygon class
+ * 
+ */
 public class QServPolygon extends Function implements QServRegion
 {
     private static final Logger log = Logger.getLogger(QServPolygon.class);
@@ -19,17 +23,28 @@ public class QServPolygon extends Function implements QServRegion
     private Expression coordsys;
     private List<Expression> points;
 
+    /**
+     * QServPolygon constructor
+     */
     public QServPolygon(List<Expression> params)
     {
         coordsys = params.remove(0);
         points = params;
     }
 
+    /**
+     * Get points
+     * @return Points expression
+     */
     public List<Expression> getPoints()
     {
         return points;
     }
-
+    
+    /**
+     * Get points in region
+     * @return The point expression
+     */
     public Expression pointInRegion(QServPoint point)
     {
         List<Expression> params = new ArrayList<Expression>();

--- a/src/main/java/org/opencadc/tap/impl/QServRegion.java
+++ b/src/main/java/org/opencadc/tap/impl/QServRegion.java
@@ -4,6 +4,10 @@ import net.sf.jsqlparser.expression.Expression;
 
 import org.opencadc.tap.impl.QServPoint;
 
+/**
+ * QServRegion interface
+ * 
+ */
 public interface QServRegion {
     public Expression pointInRegion(QServPoint point);
 }

--- a/src/main/java/org/opencadc/tap/impl/QServRegionColumn.java
+++ b/src/main/java/org/opencadc/tap/impl/QServRegionColumn.java
@@ -12,10 +12,17 @@ import net.sf.jsqlparser.schema.Table;
 
 import org.apache.log4j.Logger;
 
+/**
+ * QServRegionColumn class
+ */
 public class QServRegionColumn
 {
     private static final Logger log = Logger.getLogger(QServRegionColumn.class);
 
+    /**
+     * Get points in region
+     * @return Points as an expression object
+     */
     public static Expression pointInRegion(QServPoint point)
     {
         Function scisql = new Function();

--- a/src/main/java/org/opencadc/tap/impl/QServRegionConverter.java
+++ b/src/main/java/org/opencadc/tap/impl/QServRegionConverter.java
@@ -33,6 +33,12 @@ public class QServRegionConverter extends RegionFinder
 {
   private static Logger log = Logger.getLogger(QServRegionConverter.class);
 
+  /**
+   * QServRegionConverter constructor
+   * @param en ExpressionNavigator
+   * @param rn ReferenceNavigator
+   * @param fn FromItemNavigator
+   */
   public QServRegionConverter(ExpressionNavigator en, ReferenceNavigator rn, FromItemNavigator fn)
   {
     super(en, rn, fn);

--- a/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
+++ b/src/main/java/org/opencadc/tap/impl/ResultSetWriter.java
@@ -197,8 +197,8 @@ public class ResultSetWriter implements TableWriter<ResultSet> {
      */
     public String getErrorContentType() {
         return getContentType();
-    }
 
+    }
     /**
      * Get the extension for the VOTable.
      *
@@ -251,7 +251,6 @@ public class ResultSetWriter implements TableWriter<ResultSet> {
      * @param writer Writer to write to.
      * @throws IOException if problem writing to the writer.
      */
-    @Override
     public void write(ResultSet resultSet, Writer writer)
             throws IOException {
         write(resultSet, writer, Long.MAX_VALUE);
@@ -267,7 +266,6 @@ public class ResultSetWriter implements TableWriter<ResultSet> {
      * @param maxrec maximum number of rows to write.
      * @throws IOException if problem writing to the writer.
      */
-    @Override
     public void write(ResultSet resultSet, Writer writer, Long maxrec)
             throws IOException {
         if (formatFactory == null) {

--- a/src/main/java/org/opencadc/tap/impl/RubinTableWriter.java
+++ b/src/main/java/org/opencadc/tap/impl/RubinTableWriter.java
@@ -251,13 +251,11 @@ public class RubinTableWriter implements TableWriter
      * 
      * @return number of result rows written in output table
      */
-    @Override
     public long getRowCount()
     {
         return rowcount;
     }
     
-    @Override
     public String getExtension()
     {
         return extension;
@@ -287,37 +285,37 @@ public class RubinTableWriter implements TableWriter
         // can be determined from the table writer.
 
         switch (type) {
-        case RSS:
-            rssTableWriter = new RssTableWriter();
-            rssTableWriter.setJob(job);
-            // For error handling
-            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.TSV);
-            break;
-
-        case VOTABLE:
-            resultSetWriter = new ResultSetWriter();
-            this.contentType = resultSetWriter.getContentType();
-            this.extension = resultSetWriter.getExtension();
-            break;
-            
-        case VOTABLE_TD:
-            voDocumentWriter = new VOTableWriter();
-            this.contentType = voDocumentWriter.getContentType();
-            this.extension = voDocumentWriter.getExtension();
-            break;
-            
-        case CSV:
-            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.CSV);
-            break;
-
-        case TSV:
-            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.TSV);
-            break;
-
-        default:
-            throw new UnsupportedOperationException("unsupported format: " + type);
-	}
+	        case RSS:
+	            rssTableWriter = new RssTableWriter();
+	            rssTableWriter.setJob(job);
+	            // For error handling
+	            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.TSV);
+	            break;
 	
+	        case VOTABLE:
+	            resultSetWriter = new ResultSetWriter();
+	            this.contentType = resultSetWriter.getContentType();
+	            this.extension = resultSetWriter.getExtension();
+	            break;
+	            
+	        case VOTABLE_TD:
+	            voDocumentWriter = new VOTableWriter();
+	            this.contentType = voDocumentWriter.getContentType();
+	            this.extension = voDocumentWriter.getExtension();
+	            break;
+	            
+	        case CSV:
+	            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.CSV);
+	            break;
+	
+	        case TSV:
+	            voDocumentWriter = new AsciiTableWriter(AsciiTableWriter.ContentType.TSV);
+	            break;
+	
+	        default:
+	            throw new UnsupportedOperationException("unsupported format: " + type);
+		}
+		
 	    if (voDocumentWriter != null) {
 	        this.contentType = voDocumentWriter.getContentType();
 	        this.extension = voDocumentWriter.getExtension();
@@ -351,28 +349,10 @@ public class RubinTableWriter implements TableWriter
     @Override
     public void write(ResultSet rs, OutputStream out) throws IOException
     {
-        try (Writer writer = new BufferedWriter(new OutputStreamWriter(out, "UTF-8"))) {
-            this.write(rs, writer, null);
-        }
-    }
-
-    @Override
-    public void write(ResultSet rs, OutputStream out, Long maxrec)
-            throws IOException
-    {
-        try (Writer writer = new BufferedWriter(new OutputStreamWriter(out, "UTF-8"))) {
-            write(rs, writer, maxrec);
-        }
-    }
-
-    @Override
-    public void write(ResultSet rs, Writer out) throws IOException
-    {
         this.write(rs, out, null);
     }
 
-    @Override
-    public void write(ResultSet rs, Writer out, Long maxrec) throws IOException
+    public void write(ResultSet rs, OutputStream out, Long maxrec) throws IOException
     {
         if (rs != null && log.isDebugEnabled())
             try { log.debug("resultSet column count: " + rs.getMetaData().getColumnCount()); }

--- a/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
+++ b/src/main/java/org/opencadc/tap/schema/ALMATapSchemaDAO.java
@@ -74,6 +74,10 @@ import ca.nrc.cadc.tap.schema.TapDataType;
 import ca.nrc.cadc.tap.schema.TapSchemaDAO;
 import java.util.List;
 
+/**
+ * ALMATapSchemaDAO class
+ * 
+ */
 public class ALMATapSchemaDAO extends TapSchemaDAO {
     /**
      * Get white-list of supported functions. TAP implementors that want to allow


### PR DESCRIPTION
## Summary

In most recent changes to the cadc-dali package, they changes some of the method signatures for the TableWriter classes.
This broke our builds, so this PR addresses this by removing and adjusting some of our methods to work with the upstream interfaces.