### PR TITLE
DM-49026: Add new /reg endpoint to remove dependency on external cadc web-service

### DIFF
--- a/changelog.d/20250219_144107_steliosvoutsinas_DM_49026.md
+++ b/changelog.d/20250219_144107_steliosvoutsinas_DM_49026.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Added
+
+- New /reg endpoint for service resource-caps. Removes dependency on external ws by cadc

--- a/src/main/java/org/opencadc/tap/impl/RubinRegistryServlet.java
+++ b/src/main/java/org/opencadc/tap/impl/RubinRegistryServlet.java
@@ -1,0 +1,83 @@
+package org.opencadc.tap.impl;
+
+import org.apache.log4j.Logger;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.BufferedReader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A servlet that serves registry content from a webapp resource file.
+ *
+ * @author stvoutsin
+ */
+public class RubinRegistryServlet extends HttpServlet {
+	
+    private static final Logger log = Logger.getLogger(RubinRegistryServlet.class);
+    private static final String DEFAULT_REGISTRY_FILE = "/resource-caps";
+    
+    /**
+     * Read and return the content of the registry file from the webapp 'resource-caps' resource.
+     *
+     * @param request  the HttpServletRequest object that contains the request
+     * @param response the HttpServletResponse object that contains the response
+     * @throws ServletException if an input or output error is detected when the servlet handles the GET request
+     * @throws IOException if the request for the GET could not be handled
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) 
+        throws ServletException, IOException {
+        try {
+            String registryContent = getRegistryContent(request);
+            
+            response.setContentType("text/plain");
+            response.setCharacterEncoding("UTF-8");
+            
+            try (PrintWriter writer = response.getWriter()) {
+                writer.write(registryContent);
+            }
+        } catch (IOException e) {
+            log.error("Error serving registry content", e);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, 
+                "An error occurred while processing the request: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Reads and returns the content of the registry file from webapp resources.
+     *
+     * @param request the HttpServletRequest
+     * @return the content of the registry file as a string
+     * @throws IOException if there's an error reading the file
+     */
+    private String getRegistryContent(HttpServletRequest request) throws IOException {
+        String pathInfo = request.getPathInfo();
+        String resourcePath = DEFAULT_REGISTRY_FILE;
+        
+        if (pathInfo != null && !pathInfo.isEmpty()) {
+            resourcePath = pathInfo;
+        }
+        
+        InputStream inputStream = getServletContext().getResourceAsStream(resourcePath);
+        if (inputStream == null) {
+            throw new IOException("Registry file not found in webapp: " + resourcePath);
+        }
+        
+        StringBuilder content = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                content.append(line).append("\n");
+            }
+        }
+        
+        return content.toString();
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -133,6 +133,16 @@
         <url-pattern>/results/*</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>RubinRegistryServlet</servlet-name>
+        <servlet-class>org.opencadc.tap.impl.RubinRegistryServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>RubinRegistryServlet</servlet-name>
+        <url-pattern>/reg/*</url-pattern>
+    </servlet-mapping>
+    
     <!-- the TAP Endpoints -->
     <servlet-mapping>
         <servlet-name>AsyncServlet</servlet-name>

--- a/src/main/webapp/resource-caps
+++ b/src/main/webapp/resource-caps
@@ -1,0 +1,6 @@
+#
+# This file maps resource identifiers to the location of capability
+# information.
+#
+
+


### PR DESCRIPTION
## Summary

We recently noticed an issue where all TAP services were misbehaving with what turned out to be a broken web service at cadc: https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/reg/resource-caps. This gets queried by the RegistryClient class in the reg package of cadc, which occurs when /capabilities is checked. In this case this request was timing out due to an outage at CADC.

To address this we introduce a new '/reg' endpoint which is can be queried and returns an empty file for the '/reg/resource-caps' endpoint which is what is queried by the RegistryClient to collect additional metadata for capabilities. This does not have to contain any content in our case as our capabilities endpoints don't depend on any extra resource-caps.

