### PR TITLE
DM-49187: Upgrade to JRE 11 and set cadc-adql requirement to 1.1.14 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 group = 'org.opencadc'
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 version = '1000'
 
 war {
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.17.2'
 
     implementation 'org.opencadc:cadc-access-control-identity:[1.0.7,)'
-    implementation 'org.opencadc:cadc-adql:[1.1.13,)'
+    implementation 'org.opencadc:cadc-adql:[1.1.14,)'
     implementation 'org.opencadc:cadc-dali-pg:0.3.1'
     implementation 'org.opencadc:cadc-log:[1.2.1,)'
     implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,8 @@
 
 # Build the TAP service and docker images.
 gradle --stacktrace --info clean assemble javadoc build test
-cp build/libs/*.war docker
 
-# Apply some patches and upstream dependencies that
-# haven't been accepted yet.
-jar -uf docker/tap##1000.war -C docker/patches WEB-INF/lib/cadc-adql-1.1.13.jar
+cp build/libs/*.war docker
 
 docker build . -t lsstdax/lsst-tap-service:dev -f docker/Dockerfile.lsst-tap-service
 docker build . -t lsstdax/uws-db:dev -f docker/Dockerfile.uws-db

--- a/changelog.d/20250226_121600_steliosvoutsinas_DM_49187.md
+++ b/changelog.d/20250226_121600_steliosvoutsinas_DM_49187.md
@@ -1,0 +1,6 @@
+<!-- Delete the sections that don't apply -->
+
+### Changed
+
+- Use cadc-adql version 1.1.4
+- Upgrade to jre 11


### PR DESCRIPTION
## Summary

- Upgrade to JRE 11
- Update to cadc-adql 1.1.14
- Remove copying in patch of cadc-adql 1.1.13 since the changes have been merged in