### PR TITLE
DM-49777: Change TableServlet to use RestServlet with a jdbc/tapadm resource

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -2,6 +2,23 @@
 <Context>
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
 
+    <Resource name="jdbc/tapadm"
+              auth="Container"
+              type="javax.sql.DataSource"
+              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+              minEvictableIdleTimeMillis="30000"
+              maxActive="${tapschemauser.maxActive}" maxIdle="10" maxWait="20000" initialSize="5"
+              username="${tapschemauser.username}" password="${tapschemauser.password}"
+              driverClassName="${tapschemauser.driverClassName}"
+              url="${tapschemauser.url}"
+              removeAbandoned="false"
+              logAbandoned="true"
+              testOnBorrow="true"
+              testWhileIdle="true"
+              validationQuery="SELECT 1"
+              defaultAutoCommit="true"
+    />
+
     <Resource name="jdbc/tapuser"
               auth="Container"
               type="javax.sql.DataSource"

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -61,7 +61,11 @@
 
     <servlet>
         <servlet-name>TableServlet</servlet-name>
-        <servlet-class>ca.nrc.cadc.vosi.TableServlet</servlet-class>
+        <servlet-class>ca.nrc.cadc.rest.RestServlet</servlet-class>
+        <init-param>
+            <param-name>get</param-name>
+            <param-value>ca.nrc.cadc.vosi.actions.GetAction</param-value>
+        </init-param>
         <load-on-startup>3</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
## Summary

The TableServlet class from the vosi package is now being replaced in the ustream repos. Instead we now use RestServlet, however this requires setting up a jdbc/tapadm resource in the context so in this PR we add this as well.