### PR TITLE
DM-51463: Fix issue with binary2 uploaded table appearing empty

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/RubinUploadManagerImpl.java
+++ b/src/main/java/org/opencadc/tap/impl/RubinUploadManagerImpl.java
@@ -65,8 +65,6 @@ public class RubinUploadManagerImpl extends BasicUploadManager {
     // TSV format delimiter.
     public static final char TSV_DELI = '\t';
 
-    public static final int MAX_UPLOAD_ROWS = 100000;
-
     /**
      * Default expiration time for signed URLs in hours.
      */
@@ -78,7 +76,6 @@ public class RubinUploadManagerImpl extends BasicUploadManager {
      */
     static {
         MAX_UPLOAD = new UploadLimits(32 * 1024L * 1024L); // 32 Mb
-        MAX_UPLOAD.rowLimit = MAX_UPLOAD_ROWS;
     }
 
     /**
@@ -107,19 +104,6 @@ public class RubinUploadManagerImpl extends BasicUploadManager {
      * Storage for file metadata and signed URLs
      */
     protected Map<String, String> signedUrls;
-
-    /**
-     * Backwards compatible constructor. This uses the default byte limit of 10MiB.
-     *
-     * @param rowLimit maximum number of rows
-     * @deprecated use UploadLimits instead
-     */
-    @Deprecated
-    protected RubinUploadManagerImpl(int rowLimit) {
-        // 10MiB of votable xml is roughly 17k rows x 10 columns
-        this(new UploadLimits(10 * 1024L * 1024L));
-        this.uploadLimits.rowLimit = rowLimit;
-    }
 
     public RubinUploadManagerImpl() {
         this(MAX_UPLOAD);
@@ -309,7 +293,6 @@ public class RubinUploadManagerImpl extends BasicUploadManager {
             throws IOException {
         Writer writer = new BufferedWriter(new OutputStreamWriter(out, UTF_8));
         CsvWriter csvWriter = new CsvWriter(writer, CSV_DELI);
-
         try {
             FormatFactory formatFactory = new FormatFactory();
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,31 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO" name="TAP ObsCore">
-    <Properties>
-        <Property name="SENTRY_ENABLED">${env:SENTRY_DSN:-}</Property>
-    </Properties>
-    
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %c [%t] %-5p %m%n"/>
         </Console>
-        
-        <!-- Sentry Appender - Only created if SENTRY_DSN is set -->
-        <Sentry name="Sentry" 
-            minimumEventLevel="ERROR"
-            minimumBreadcrumbLevel="WARN">
-            <filters>
-                <!-- Only allow if SENTRY_DSN is not empty -->
-                <StringMatchFilter text="${SENTRY_ENABLED}" onMatch="ACCEPT" onMismatch="DENY"/>
-            </filters>
-        </Sentry>
     </Appenders>
-
+    
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
-            <AppenderRef ref="Sentry" level="ERROR"/>
         </Root>
         <Logger name="org.apache.kafka" level="INFO"/>
-
     </Loggers>
 </Configuration>

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -106,8 +106,8 @@
     </outputLimit>
     <!-- outputLimit for sync queries: no limit -->
     <uploadLimit>
-      <default unit="byte">10485760</default>
-      <hard unit="byte">10485760</hard>
+      <default unit="byte">33554432</default>
+      <hard unit="byte">33554432</hard>
     </uploadLimit>
   </capability>
 


### PR DESCRIPTION
## Summary
- Fixes issue with binary2 uploaded table appearing empty, by removing deprecated rowlimit-based upload constructor
- Also fixes logging issue, by removing Sentry logging for now 
- Update capabilities to show proper file size limit

Addresses JIRA issues:
- https://rubinobs.atlassian.net/browse/DM-51463
- https://rubinobs.atlassian.net/browse/DM-51458