### PR TITLE
DM-51730: Enable setting the availability via a system property

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -41,7 +41,7 @@
               type="javax.sql.DataSource"
               factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
               minEvictableIdleTimeMillis="30000"
-              maxActive="${qservuser.maxActive}" maxIdle="1" maxWait="20000" initialSize="5"
+              maxActive="${qservuser.maxActive}" maxIdle="1" maxWait="20000" initialSize="0"
               username="${qservuser.username}" password="${qservuser.password}"
               driverClassName="${qservuser.driverClassName}"
               url="${qservuser.url}"


### PR DESCRIPTION
- Modify TAP ws to use property and provide a downtime message if tap.service.available is fale
- Change KafkaJobExecutor to return VOTable errors instead of sending the queries through if available is false
- Set initial number of connections to QServ to 0, to allow service to startup when QServ is not available