### PR TITLE
DM-51834: Add support for unicodeChar for uploaded tables

### DIFF
--- a/src/main/java/org/opencadc/tap/kafka/util/VOTableUtil.java
+++ b/src/main/java/org/opencadc/tap/kafka/util/VOTableUtil.java
@@ -226,6 +226,8 @@ public class VOTableUtil {
                 return "float";
             case "DOUBLE":
                 return "double";
+            case "UNICODECHAR":
+                return "unicodeChar";
             case "CHAR":
             case "VARCHAR":
             case "STRING":


### PR DESCRIPTION
Simply add UnicodeChar as an available type in `convertTapDataTypeToVOTableType` in the VOTableUtil class so that we can handle unicodeChar as an uploaded table field.