### PR TITLE
DM-52477: Fix capabilities so that we only advertise votable/binary2 as the output format

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/uws/server/KafkaJobExecutor.java
+++ b/src/main/java/org/opencadc/tap/impl/uws/server/KafkaJobExecutor.java
@@ -6,17 +6,10 @@ import java.io.IOException;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.util.Date;
-import java.util.Set;
-
 import javax.security.auth.Subject;
-
-import ca.nrc.cadc.auth.AuthMethod;
-import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.auth.RunnableAction;
 import ca.nrc.cadc.net.TransientException;
 import ca.nrc.cadc.rest.SyncOutput;
-import ca.nrc.cadc.tap.QueryRunner;
 import ca.nrc.cadc.uws.ErrorType;
 import ca.nrc.cadc.uws.ExecutionPhase;
 import ca.nrc.cadc.uws.Job;
@@ -28,7 +21,6 @@ import ca.nrc.cadc.uws.server.JobPhaseException;
 import ca.nrc.cadc.uws.server.JobRunner;
 import ca.nrc.cadc.uws.server.JobUpdater;
 
-import org.opencadc.tap.impl.QServQueryRunner;
 import org.opencadc.tap.impl.logging.TAPLogger;
 import org.opencadc.tap.kafka.services.CreateDeleteEvent;
 import org.opencadc.tap.kafka.services.CreateJobEvent;

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -73,20 +73,12 @@
         <!-- REGION, INTERSECTS, AREA, CENTROID, COORD1, and COORD2 not supported by Qserv -->
       </languageFeatures>
     </language>
-    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-td">
+    <outputFormat ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
       <mime>application/x-votable+xml</mime>
       <alias>votable</alias>
     </outputFormat>
-    <outputFormat  ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-td">
+    <outputFormat  ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
       <mime>text/xml</mime>
-    </outputFormat>
-    <outputFormat>
-      <mime>text/csv</mime>
-      <alias>csv</alias>
-    </outputFormat>
-    <outputFormat>
-      <mime>text/tab-separated-values</mime>
-      <alias>tsv</alias>
     </outputFormat>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-inline"/>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-http"/>


### PR DESCRIPTION
This PR fixes a few issues related to validation:
- Update capabilities to correctly advertise only the formats we currently support
- Allow aborting jobs that have not been started
- Write error messages we get in the Job Status updates as error VOTables to GCS.

Related JIRA issues:

- https://rubinobs.atlassian.net/browse/DM-52483
- https://rubinobs.atlassian.net/browse/DM-52479
- https://rubinobs.atlassian.net/browse/DM-52477