### PR TITLE
DM-55098: Add support for optionally advertising VOParquet as an available format

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/CapInitAction.java
+++ b/src/main/java/org/opencadc/tap/impl/CapInitAction.java
@@ -165,6 +165,18 @@ public class CapInitAction extends InitAction {
             tmpl = tmpl.replace("${tap.outputLimitUnit}", outputLimitUnit);
             log.debug("doInit: tap.outputLimit=" + outputLimit + " tap.outputLimitUnit=" + outputLimitUnit);
 
+            String enableVOParquet = System.getProperty("tap.enableVOParquet", "false");
+            if ("true".equalsIgnoreCase(enableVOParquet)) {
+                String voparquetFormat = "<outputFormat>\n"
+                    + "      <mime>application/vnd.apache.parquet</mime>\n"
+                    + "      <alias>parquet</alias>\n"
+                    + "    </outputFormat>";
+                tmpl = tmpl.replace("${tap.voparquet.outputFormat}", voparquetFormat);
+            } else {
+                tmpl = tmpl.replace("${tap.voparquet.outputFormat}", "");
+            }
+            log.debug("doInit: tap.enableVOParquet=" + enableVOParquet);
+
             // validate
             CapabilitiesReader cr = new CapabilitiesReader();
             cr.read(tmpl);

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -80,6 +80,7 @@
     <outputFormat  ivo-id="ivo://ivoa.net/std/TAPRegExt#output-votable-binary">
       <mime>text/xml</mime>
     </outputFormat>
+    ${tap.voparquet.outputFormat}
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-inline"/>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-http"/>
     <uploadMethod ivo-id="ivo://ivoa.net/std/TAPRegExt#upload-https"/>


### PR DESCRIPTION
We currently don't advertise voparquet as an available format. 
This PR adds a configurable option which when enabled adds it to the output formats of capabilities