### PR TITLE
DM-55625: Fix bug in BigQuery translator when query includes a HAVING COUNT(*) > expression

### DIFF
--- a/changelog.d/20260724_230421_steliosvoutsinas_DM_55625.md
+++ b/changelog.d/20260724_230421_steliosvoutsinas_DM_55625.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Fixed
+
+- Fix bug in BigQuery translator when query includes a HAVING COUNT(*) > .. expression

--- a/src/main/java/org/opencadc/tap/dialect/bigquery/parser/converter/BigQueryRegionConverter.java
+++ b/src/main/java/org/opencadc/tap/dialect/bigquery/parser/converter/BigQueryRegionConverter.java
@@ -310,8 +310,12 @@ import java.util.*;
      }
  
      private Expression getInternalMeasureFunction(Expression expression) {
-         List<Expression> measureFunctionParams = ((Function) expression).getParameters().getExpressions();
- 
+         ExpressionList parameters = ((Function) expression).getParameters();
+         if (parameters == null) {
+             return null;   // e.g. COUNT(*) has no parameter list to inspect
+         }
+         List<Expression> measureFunctionParams = parameters.getExpressions();
+
          return measureFunctionParams
                  .stream()
                  .filter(exp -> isFunction(exp) && MEASURE_FUNCTIONS.contains(((Function) exp).getName()))


### PR DESCRIPTION
# Bug

Queries with HAVING COUNT(*) as an expression fail with an ADQL error:

## Query:
```
SELECT TOP 1
  "diaForcedSourceId", COUNT(*) AS duplicate_count
FROM ppdb.DiaForcedSource
GROUP BY "diaForcedSourceId"
HAVING COUNT(*) > 1

```
The UWS error is:
```
Cannot invoke ... ExpressionList.getExpressions() because ...
Function.getParameters() is null
```

## Fix
- If the function has no parameter list, it can't contain a measure function, so return null