### PR TITLE
DM-55640: Add execid prefx to UWS output for qserv executionID

### DIFF
--- a/changelog.d/20260727_185539_steliosvoutsinas_DM_55640.md
+++ b/changelog.d/20260727_185539_steliosvoutsinas_DM_55640.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Changed
+
+- Add execid prefx to UWS output for qserv executionID

--- a/src/main/java/org/opencadc/tap/kafka/services/JobStatusListener.java
+++ b/src/main/java/org/opencadc/tap/kafka/services/JobStatusListener.java
@@ -308,7 +308,7 @@ public class JobStatusListener implements ReadJobStatus.StatusListener {
             Boolean skipExecutionId = false;
 
             if (status.getExecutionID() != null && !status.getExecutionID().trim().isEmpty()) {
-                metadata.add(new Result("executionId", URI.create(status.getExecutionID())));
+                metadata.add(new Result("executionId", URI.create("execid:" + status.getExecutionID())));
             } else {
                 log.warn("ExecutionID is null or empty for job: " + status.getJobID());
             }

--- a/src/main/java/org/opencadc/tap/kafka/util/KafkaJobService.java
+++ b/src/main/java/org/opencadc/tap/kafka/util/KafkaJobService.java
@@ -170,7 +170,7 @@ public class KafkaJobService {
         if (job.getResultsList() != null) {
             for (Result result : job.getResultsList()) {
                 if (result.getName().equals("executionId")) {
-                    executionId = result.getURI().toString();
+                    executionId = result.getURI().getSchemeSpecificPart();
                 }
             }
         }


### PR DESCRIPTION
Add `execid:` scheme to `executionID` output to ensure clients don't misinterpret the content.