### PR TITLE
DM-55648: Forward job timeout to bridge / Make timeout & signed URL lifetime configurable

### DIFF
--- a/src/main/java/org/opencadc/tap/impl/CapInitAction.java
+++ b/src/main/java/org/opencadc/tap/impl/CapInitAction.java
@@ -91,6 +91,8 @@ public class CapInitAction extends InitAction {
     private static final Logger log = Logger.getLogger(CapInitAction.class);
     private static final String DEFAULT_OUTPUT_LIMIT = "100000000";
     private static final String DEFAULT_OUTPUT_LIMIT_UNIT = "row";
+    // Must match QueryJobManager's default for the same "tap.maxExecutionDuration"
+    private static final String DEFAULT_MAX_EXECUTION_DURATION = String.valueOf(4 * 3600L);
     /**
      * Default constructor for CapInitAction.
      * 
@@ -164,6 +166,11 @@ public class CapInitAction extends InitAction {
             tmpl = tmpl.replace("${tap.outputLimit}", outputLimit);
             tmpl = tmpl.replace("${tap.outputLimitUnit}", outputLimitUnit);
             log.debug("doInit: tap.outputLimit=" + outputLimit + " tap.outputLimitUnit=" + outputLimitUnit);
+
+            String maxExecutionDuration = System.getProperty(
+                    "tap.maxExecutionDuration", DEFAULT_MAX_EXECUTION_DURATION);
+            tmpl = tmpl.replace("${tap.maxExecutionDuration}", maxExecutionDuration);
+            log.debug("doInit: tap.maxExecutionDuration=" + maxExecutionDuration);
 
             String enableVOParquet = System.getProperty("tap.enableVOParquet", "false");
             if ("true".equalsIgnoreCase(enableVOParquet)) {

--- a/src/main/java/org/opencadc/tap/kafka/services/CreateJobEvent.java
+++ b/src/main/java/org/opencadc/tap/kafka/services/CreateJobEvent.java
@@ -77,7 +77,7 @@ public class CreateJobEvent implements AutoCloseable {
 
     /**
      * Submit a query to be executed with optional parameters
-     * 
+     *
      * @param query             SQL query to execute
      * @param jobID             Specific job identifier
      * @param resultDestination Result destination for the query
@@ -91,8 +91,33 @@ public class CreateJobEvent implements AutoCloseable {
      * @throws InterruptedException if the operation is interrupted
      */
     public String submitQuery(String query, String jobID, String resultDestination, String resultLocation,
-            ResultFormat resultFormat, String ownerID, String database, Integer maxrec, 
+            ResultFormat resultFormat, String ownerID, String database, Integer maxrec,
             List<UploadTable> uploadTables)
+            throws ExecutionException, InterruptedException {
+        return submitQuery(query, jobID, resultDestination, resultLocation, resultFormat, ownerID,
+                database, maxrec, uploadTables, null);
+    }
+
+    /**
+     * Submit a query to be executed with optional parameters, including an execution timeout.
+     *
+     * @param query             SQL query to execute
+     * @param jobID             Specific job identifier
+     * @param resultDestination Result destination for the query
+     * @param resultLocation    Optional custom result location
+     * @param resultFormat      Optional custom result format
+     * @param ownerID           Owner identifier
+     * @param database          Optional database to query
+     * @param maxrec            Optional maximum number of records
+     * @param uploadTables      Optional list of upload tables
+     * @param timeout           Optional query execution timeout, in seconds
+     * @return Job ID for the submitted query
+     * @throws ExecutionException   if sending to Kafka fails
+     * @throws InterruptedException if the operation is interrupted
+     */
+    public String submitQuery(String query, String jobID, String resultDestination, String resultLocation,
+            ResultFormat resultFormat, String ownerID, String database, Integer maxrec,
+            List<UploadTable> uploadTables, Integer timeout)
             throws ExecutionException, InterruptedException {
 
         if (closed.get()) {
@@ -126,6 +151,7 @@ public class CreateJobEvent implements AutoCloseable {
                     .setResultFormat(resultFormat)
                     .setDatabase(database)
                     .setUploadTables(uploadTables)
+                    .setTimeout(timeout)
                     .build();
 
             String jsonString = jobRun.toJsonString();

--- a/src/main/java/org/opencadc/tap/kafka/util/KafkaJobService.java
+++ b/src/main/java/org/opencadc/tap/kafka/util/KafkaJobService.java
@@ -32,7 +32,6 @@ import org.opencadc.tap.impl.StorageUtils;
 import org.opencadc.tap.kafka.models.JobRun.UploadTable;
 import org.opencadc.tap.kafka.models.OutputFormat;
 import org.opencadc.tap.kafka.models.JobRun;
-import org.opencadc.tap.kafka.util.DatabaseNameUtil;
 import org.opencadc.tap.kafka.services.CreateDeleteEvent;
 import org.opencadc.tap.kafka.services.CreateJobEvent;
 import org.opencadc.tap.impl.context.WebAppContext;
@@ -47,7 +46,15 @@ import org.opencadc.tap.impl.context.WebAppContext;
 public class KafkaJobService {
     private static final Logger log = Logger.getLogger(KafkaJobService.class);
 
-    private static final int DEFAULT_JOB_RESULT_EXPIRATION_MINUTES = 120;
+    // Buffer added on top of the max execution duration
+    // Accounts for qserv-kafka result processing time
+    private static final int RESULT_DELIVERY_BUFFER_MINUTES = 60;
+
+    // Derived from "tap.maxExecutionDuration" (same property as QueryJobManager)
+    // We want to make sure the signed result URL lifetime is longer than the max query time.
+    private static final int DEFAULT_JOB_RESULT_EXPIRATION_MINUTES =
+            (int) (Long.parseLong(System.getProperty("tap.maxExecutionDuration", "14400")) / 60)
+            + RESULT_DELIVERY_BUFFER_MINUTES;
 
     private static final UploadPartitionDetector PARTITION_DETECTOR =
             new UploadPartitionDetector(System.getProperty("upload.partition.directors", ""));
@@ -107,7 +114,8 @@ public class KafkaJobService {
                     jobInfo.ownerID,
                     databaseString,
                     jobInfo.maxrec,
-                    jobInfo.uploadTables);
+                    jobInfo.uploadTables,
+                    jobInfo.timeout);
 
             log.debug("Job sent to Kafka successfully with event ID: " + eventJobId);
 
@@ -274,6 +282,11 @@ public class KafkaJobService {
             info.resultFormat = VOTableUtil.createResultFormat(job.getID(), queryRunner, format);
             info.maxrec = queryRunner.maxRows;
 
+            Long executionDuration = job.getExecutionDuration();
+            if (executionDuration != null && executionDuration > 0) {
+                info.timeout = executionDuration.intValue();
+            }
+
             try {
 
                 if (!queryRunner.uploadTableLocations.isEmpty()) {
@@ -346,6 +359,7 @@ public class KafkaJobService {
         JobRun.ResultFormat resultFormat = null;
         String ownerID = "";
         Integer maxrec = null;
+        Integer timeout = null;
         List<UploadTable> uploadTables = new ArrayList<>();
     }
 

--- a/src/main/java/org/opencadc/tap/ws/QueryJobManager.java
+++ b/src/main/java/org/opencadc/tap/ws/QueryJobManager.java
@@ -18,10 +18,17 @@ import ca.nrc.cadc.uws.server.RandomStringGenerator;
  * @author pdowler
  */
 public class QueryJobManager extends SimpleJobManager {
-    private static final long MAX_EXEC_DURATION = 4 * 3600L;    // 4 hours to dump a catalog to vpsace
-    private static final long MAX_DESTRUCTION = 7 * 24 * 60 * 60L; // 1 week
-    private static final long MAX_QUOTE = 24 * 3600L;         // 24 hours since we have a threadpool with
+    private static final long DEFAULT_MAX_EXEC_DURATION = 4 * 3600L;
+    private static final long DEFAULT_MAX_DESTRUCTION = 7 * 24 * 60 * 60L; // 1 week
+    private static final long DEFAULT_MAX_QUOTE = 24 * 3600L; // 24 hours since we have a threadpool with
     // queued jobs
+
+    private static final long MAX_EXEC_DURATION = Long.parseLong(
+            System.getProperty("tap.maxExecutionDuration", String.valueOf(DEFAULT_MAX_EXEC_DURATION)));
+    private static final long MAX_DESTRUCTION = Long.parseLong(
+            System.getProperty("tap.maxDestruction", String.valueOf(DEFAULT_MAX_DESTRUCTION)));
+    private static final long MAX_QUOTE = Long.parseLong(
+            System.getProperty("tap.maxQuote", String.valueOf(DEFAULT_MAX_QUOTE)));
 
     public QueryJobManager() {
         super();
@@ -32,7 +39,7 @@ public class QueryJobManager extends SimpleJobManager {
 
         // max threads: 6 == number of simultaneously running async queries (per
         // web server), plus sync queries, plus VOSI-tables queries
-        
+
         final JobExecutor jobExec = KafkaJobExecutorFactory.createExecutor(jobPersist, RubinQueryRunner.class, jobPersist);
 
         super.setJobPersistence(jobPersist);

--- a/src/main/webapp/capabilities.xml
+++ b/src/main/webapp/capabilities.xml
@@ -89,8 +89,8 @@
       <hard>604800</hard>
     </retentionPeriod>
     <executionDuration>
-      <default>600</default>
-      <hard>600</hard>
+      <default>${tap.maxExecutionDuration}</default>
+      <hard>${tap.maxExecutionDuration}</hard>
     </executionDuration>
     <outputLimit>
       <default unit="${tap.outputLimitUnit}">${tap.outputLimit}</default>


### PR DESCRIPTION
## Changes
- Forward UWS execution duration to qserv-kafka
- Make timeout & URL expiration limits configurable via system properties