### PR TITLE
DM-55657: Fix quoted identifier bug in BigQuery translator

### DIFF
--- a/src/main/java/org/opencadc/tap/dialect/bigquery/expression/BigQueryExpressionDeParser.java
+++ b/src/main/java/org/opencadc/tap/dialect/bigquery/expression/BigQueryExpressionDeParser.java
@@ -69,7 +69,9 @@
 package org.opencadc.tap.dialect.bigquery.expression;
 
 import ca.nrc.cadc.tap.parser.BaseExpressionDeParser;
+import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
+import org.opencadc.tap.dialect.bigquery.parser.BigQueryQuerySelectDeParser;
 
 public class BigQueryExpressionDeParser extends BaseExpressionDeParser {
     public BigQueryExpressionDeParser(SelectVisitor selectVisitor, StringBuffer buffer) {
@@ -78,5 +80,14 @@ public class BigQueryExpressionDeParser extends BaseExpressionDeParser {
 
     void visit(BigQueryKeywordExpression expression) {
         buffer.append(expression.toString());
+    }
+
+    /**
+     * Covers columns deparsed inside expressions (WHERE, HAVING, join ON).
+     */
+    @Override
+    public void visit(Column tableColumn) {
+        BigQueryQuerySelectDeParser.normalizeColumnQuotes(tableColumn);
+        super.visit(tableColumn);
     }
 }

--- a/src/main/java/org/opencadc/tap/dialect/bigquery/parser/BigQueryQuerySelectDeParser.java
+++ b/src/main/java/org/opencadc/tap/dialect/bigquery/parser/BigQueryQuerySelectDeParser.java
@@ -87,14 +87,30 @@ import net.sf.jsqlparser.statement.select.SelectExpressionItem;
          Expression selectExpression = selectExpressionItem.getExpression();
  
          if (selectExpression instanceof Column) {
-             String normalizedColumnName = ((Column) selectExpression).getColumnName().replaceAll("\"", "");
-             ((Column) selectExpression).setColumnName(normalizedColumnName);
+             normalizeColumnQuotes((Column) selectExpression);
          }
- 
+
          if (selectExpressionItem instanceof BigQueryColumnAliasSelectItem) {
              getBuffer().append(selectExpressionItem);
          } else {
              super.visit(selectExpressionItem);
          }
+     }
+
+     /**
+      * Covers columns deparsed outside the select list (GROUP BY, ORDER BY).
+      */
+     @Override
+     public void visit(Column column) {
+         normalizeColumnQuotes(column);
+         super.visit(column);
+     }
+
+     /**
+      * ADQL delimited identifiers are double-quoted, but BigQuery reads double
+      * quotes as string literals.
+      */
+     public static void normalizeColumnQuotes(Column column) {
+         column.setColumnName(column.getColumnName().replaceAll("\"", ""));
      }
  }


### PR DESCRIPTION
## Description
Quoted column references in BigQuery queries are treated as string literals, so we need to catch those and strip them.